### PR TITLE
Read the allocated port from the ServerSocket

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/server/AbstractServer.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/server/AbstractServer.java
@@ -159,7 +159,7 @@ public abstract class AbstractServer extends Service {
     }
 
     public int getPort() {
-        return setup.getPort();
+        return serverSocket.getLocalPort();
     }
 
     public String getProtocol() {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/server/AbstractServer_AllocateAvailablePortTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/server/AbstractServer_AllocateAvailablePortTest.java
@@ -1,0 +1,41 @@
+package com.icegreen.greenmail.server;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import javax.mail.internet.MimeMessage;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+
+public class AbstractServer_AllocateAvailablePortTest {
+
+    private static final int AnyFreePort = 0;
+
+    private final ServerSetup allocateAnyFreePortForAnSmtpServer = smtpServerAtPort(AnyFreePort);
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(allocateAnyFreePortForAnSmtpServer);
+
+    @Test
+    public void returnTheActuallyAllocatedPort() throws Exception {
+        assertThat(greenMail.getSmtp().getPort(), not(0));
+    }
+
+    @Test
+    public void ensureThatMailCanActuallyBeSentToTheAllocatedPort() throws Exception {
+        GreenMailUtil.sendTextEmail("to@localhost.com", "from@localhost.com", "subject", "body", smtpServerAtPort(greenMail.getSmtp().getPort()));
+
+        MimeMessage[] emails = greenMail.getReceivedMessages();
+        assertThat(emails.length, is(1));
+    }
+
+    private ServerSetup smtpServerAtPort(int port) {
+        return new ServerSetup(port, null, ServerSetup.PROTOCOL_SMTP);
+    }
+}


### PR DESCRIPTION
ServerSocket has support to search for any free
port if you pass '0' as port number. In this case
the port in the ServerSetup does not match the
actually acquired port.
