### PR TITLE
Fixed bug in #28. Modified MailCommand class to avoid populating the sen...

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/MailCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/MailCommand.java
@@ -37,18 +37,22 @@ public class MailCommand
             if (m.matches()) {
                 String from = m.group(1);
 
-                MailAddress fromAddr = new MailAddress(from);
-
-                String err = manager.checkSender(state, fromAddr);
-                if (err != null) {
-                    conn.send(err);
-
-                    return;
+                if (!from.isEmpty()) {
+                    MailAddress fromAddr = new MailAddress(from);
+                    String err = manager.checkSender(state, fromAddr);
+                    if (err != null) {
+                        conn.send(err);
+                        return;
+                    }
+                    state.clearMessage();
+                    state.getMessage().setReturnPath(fromAddr);
+                    conn.send("250 OK");
+                } else {
+                	state.clearMessage();
+                	state.getMessage();
+                	conn.send("250 OK");
                 }
 
-                state.clearMessage();
-                state.getMessage().setReturnPath(fromAddr);
-                conn.send("250 OK");
             } else {
                 conn.send("501 Required syntax: 'MAIL FROM:<email@host>'");
             }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/SMTPCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/SMTPCommandTest.java
@@ -1,0 +1,54 @@
+package com.icegreen.greenmail.test.commands;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.ServerSetupTest;
+
+public class SMTPCommandTest {
+	
+	@Rule
+	public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.ALL);
+
+	@Test
+	public void MailSenderEmpty() throws UnknownHostException, IOException {
+		Socket smtpSocket = null;
+		DataOutputStream dos = null; 
+		BufferedReader br = null;
+		String hostAddress = greenMail.getSmtp().getBindTo();
+		int port = greenMail.getSmtp().getPort();
+		
+		try {
+			smtpSocket = new Socket(hostAddress,port);
+			dos = new DataOutputStream(smtpSocket.getOutputStream());
+			br = new BufferedReader(new InputStreamReader(smtpSocket.getInputStream()));
+		} finally {
+			
+		}
+		
+		assertEquals("220 /" + hostAddress + " GreenMail SMTP Service Ready at port " + port,br.readLine());
+		dos.writeBytes("HELO " + hostAddress);
+		dos.writeBytes("\n");
+		assertEquals("250 /" + hostAddress,br.readLine());
+		dos.writeBytes("MAIL FROM: <>");
+		dos.writeBytes("\n");
+		assertEquals("250 OK",br.readLine());
+		dos.flush();
+		br.close();
+		dos.close();
+
+		smtpSocket.close();
+		
+	}
+
+}


### PR DESCRIPTION
...der field if it's empty per RFC5321 specifications.

Added a unit test class SMTPCommandTest to test socket level commands to GreenMail SMTP server.
