### PR TITLE
Don't quit() from within the run() method

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/server/AbstractServer.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/server/AbstractServer.java
@@ -80,42 +80,38 @@ public abstract class AbstractServer extends Service {
     @Override
     public void run() {
         try {
-            try {
-                serverSocket = openServerSocket();
-                setRunning(true);
-                synchronized (this) {
-                    this.notifyAll();
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            serverSocket = openServerSocket();
+            setRunning(true);
+            synchronized (this) {
+                this.notifyAll();
             }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
-            while (keepOn()) {
-                try {
-                    Socket clientSocket = serverSocket.accept();
-                    if (!keepOn()) {
-                        clientSocket.close();
-                    } else {
-                        final ProtocolHandler handler = createProtocolHandler(clientSocket);
-                        addHandler(handler);
-                        new Thread(new Runnable() {
-                            @Override
-                            public void run() {
-                                handler.run(); // NOSONAR
-                                 // Make sure to deregister, see https://github.com/greenmail-mail-test/greenmail/issues/18
-                                removeHandler(handler);
-                            }
-                        }).start();
-                    }
-                } catch (IOException ignored) {
-                    //ignored
-                    if(log.isTraceEnabled()) {
-                        log.trace("Error while processing socket", ignored);
-                    }
+        while (keepOn()) {
+            try {
+                Socket clientSocket = serverSocket.accept();
+                if (!keepOn()) {
+                    clientSocket.close();
+                } else {
+                    final ProtocolHandler handler = createProtocolHandler(clientSocket);
+                    addHandler(handler);
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            handler.run(); // NOSONAR
+                             // Make sure to deregister, see https://github.com/greenmail-mail-test/greenmail/issues/18
+                            removeHandler(handler);
+                        }
+                    }).start();
+                }
+            } catch (IOException ignored) {
+                //ignored
+                if(log.isTraceEnabled()) {
+                    log.trace("Error while processing socket", ignored);
                 }
             }
-        } finally {
-            quit();
         }
     }
 
@@ -138,7 +134,7 @@ public abstract class AbstractServer extends Service {
     }
 
     @Override
-    public synchronized void quit() {
+    protected synchronized void quit() {
         try {
             synchronized (handlers) {
                 for (ProtocolHandler handler : handlers) {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/Service.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/Service.java
@@ -14,7 +14,7 @@ package com.icegreen.greenmail.util;
 abstract public class Service extends Thread {
     public abstract void run();
 
-    public abstract void quit();
+    protected abstract void quit();
 
     private volatile boolean keepRunning = false;
     private volatile boolean running = false;


### PR DESCRIPTION
This ensure that cleanup code always gets executed only once, from the calling
thread.

Main thread calls `stopService()`, `quit()`, then `quit()` will get called
again when the thread terminates. On Android this code actually causes
a deadlock since `Thread.join()` does not release the monitor/lock there and `quit()`
never gets called.

This PR also changes the visibility of the `quit()` method since it is
only used internally.