### PR TITLE
Add capability to define users that should be automaticaly created when servers start

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
@@ -1,18 +1,25 @@
 package com.icegreen.greenmail.junit;
 
-import com.icegreen.greenmail.util.GreenMail;
-import com.icegreen.greenmail.util.GreenMailProxy;
-import com.icegreen.greenmail.util.ServerSetup;
-import com.icegreen.greenmail.util.ServerSetupTest;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailProxy;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
+
 public class GreenMailRule extends GreenMailProxy implements MethodRule, TestRule {
     private GreenMail greenMail;
     private final ServerSetup[] serverSetups;
+
+    private final List<UserBean> usersToCreate = new ArrayList<UserBean>();
 
     /**
      * Initialize with multiple server setups
@@ -48,6 +55,13 @@ public class GreenMailRule extends GreenMailProxy implements MethodRule, TestRul
             public void evaluate() throws Throwable {
                 greenMail = new GreenMail(serverSetups);
                 greenMail.start();
+                for (final UserBean user : usersToCreate) {
+                    if (user.getEmail() != null) {
+                        greenMail.setUser(user.getEmail(), user.getLogin(), user.getPassword());
+                    } else {
+                        greenMail.setUser(user.getLogin(), user.getPassword());
+                    }
+                }
                 try {
                     base.evaluate();
                 } finally {
@@ -61,6 +75,54 @@ public class GreenMailRule extends GreenMailProxy implements MethodRule, TestRul
     @Override
     protected GreenMail getGreenMail() {
         return greenMail;
+    }
+
+    /**
+     * A user to create when servers start
+     * 
+     * @author Christophe DENEUX - Linagora
+     *
+     */
+    private class UserBean {
+        final String email;
+
+        final String login;
+
+        final String password;
+
+        public UserBean(final String email, final String login, final String password) {
+            this.email = email;
+            this.login = login;
+            this.password = password;
+        }
+
+        public String getEmail() {
+            return this.email;
+        }
+
+        public String getLogin() {
+            return this.login;
+        }
+
+        public String getPassword() {
+            return this.password;
+        }
+    }
+
+    /**
+     * The given {@link GreenMailUser} will be created when servers will start
+     */
+    public GreenMailRule addUser(final String login, final String password) {
+        this.usersToCreate.add(new UserBean(null, login, password));
+        return this;
+    }
+
+    /**
+     * The given {@link GreenMailUser} will be created when servers will start
+     */
+    public GreenMailRule addUser(final String email, final String login, final String password) {
+        this.usersToCreate.add(new UserBean(email, login, password));
+        return this;
     }
 }
 


### PR DESCRIPTION
Such a capability is required when using GreenMail in combination with other JUnit rules that listen mails. In the following example, the component under test start a listener to read mail from a given mailbox that must exist. So the method GreenMailRule.addUser() defines a user that will be created just after the mail server startups, and before the startup of the component under test :
```java
    private static final GreenMailRule MAIL_SERVER = new GreenMailRule().addUser(INCOMING_ACCOUNT_ADDRESS_TO, INCOMING_ACCOUNT_USER, INCOMING_ACCOUNT_PWD);
    private static final ComponentUnderTest COMPONENT_UNDER_TEST = new ComponentUnderTest();

    @ClassRule
    public static final TestRule chain = RuleChain.outerRule(IN_MEMORY_LOG_HANDLER).around(MAIL_SERVER).around(COMPONENT_UNDER_TEST);