### PR TITLE
Feature/greenmail config

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
@@ -1,6 +1,7 @@
-package com.icegreen.greenmail.util;
+package com.icegreen.greenmail.base;
 
 import com.icegreen.greenmail.Managers;
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.imap.ImapServer;
 import com.icegreen.greenmail.pop3.Pop3Server;
 import com.icegreen.greenmail.smtp.SmtpServer;
@@ -113,6 +114,13 @@ public interface GreenMailOperations {
      * @param isEnabled true, if quotas should be supported.
      */
     void setQuotaSupported(boolean isEnabled);
+
+    /**
+     * Configure GreenMail instance using the given configuration
+     *
+     * @param config Configuration to use
+     */
+    GreenMailOperations withConfiguration(GreenMailConfiguration config);
 
     /**
      * Start the GreenMail server

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
@@ -1,0 +1,27 @@
+package com.icegreen.greenmail.configuration;
+
+import com.icegreen.greenmail.base.GreenMailOperations;
+
+/**
+ * A version of GreenMailOperations that implements the configure() method.
+ */
+public abstract class ConfiguredGreenMail implements GreenMailOperations {
+    private GreenMailConfiguration config;
+
+    @Override
+    public ConfiguredGreenMail withConfiguration(GreenMailConfiguration config) {
+        this.config = config;
+        return this;
+    }
+
+    /**
+     * This method can be used by child classes to apply the configuration that is stored in config.
+     */
+    protected void doConfigure() {
+        if (config != null) {
+            for (UserBean user : config.getUsersToCreate()) {
+                setUser(user.getEmail(), user.getLogin(), user.getPassword());
+            }
+        }
+    }
+}

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
@@ -1,0 +1,50 @@
+package com.icegreen.greenmail.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Properties that can be defined to configure a GreenMail instance or GreenMailRule.
+ */
+public class GreenMailConfiguration {
+    private final List<UserBean> usersToCreate = new ArrayList<UserBean>();
+
+    /**
+     * The given {@link com.icegreen.greenmail.user.GreenMailUser} will be created when servers will start
+     *
+     * @param login User id and email addres
+     * @param password Password of user that belongs to login name
+     * @return Modified configuration
+     */
+    public GreenMailConfiguration withUser(final String login, final String password) {
+        this.usersToCreate.add(new UserBean(login, login, password));
+        return this;
+    }
+
+    /**
+     * The given {@link com.icegreen.greenmail.user.GreenMailUser} will be created when servers will start
+     *
+     * @param email Email address
+     * @param login Login name of user
+     * @param password Password of user that belongs to login name
+     * @return Modified configuration
+     */
+    public GreenMailConfiguration withUser(final String email, final String login, final String password) {
+        this.usersToCreate.add(new UserBean(email, login, password));
+        return this;
+    }
+
+    /**
+     * @return New GreenMail configuration
+     */
+    public static GreenMailConfiguration aConfig() {
+        return new GreenMailConfiguration();
+    }
+
+    /**
+     * @return Users that should be created on server startup
+     */
+    public List<UserBean> getUsersToCreate() {
+        return usersToCreate;
+    }
+}

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/UserBean.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/UserBean.java
@@ -1,0 +1,40 @@
+package com.icegreen.greenmail.configuration;
+
+/**
+ * A user to create when servers start
+ */
+public class UserBean {
+    private final String email;
+    private final String login;
+    private final String password;
+
+    /**
+     * Initialize user
+     */
+    public UserBean(final String email, final String login, final String password) {
+        this.email = email;
+        this.login = login;
+        this.password = password;
+    }
+
+    /**
+     * @return Email address of mail box
+     */
+    public String getEmail() {
+        return this.email;
+    }
+
+    /**
+     * @return Login name of user
+     */
+    public String getLogin() {
+        return this.login;
+    }
+
+    /**
+     * @return Password of user that belongs to login name
+     */
+    public String getPassword() {
+        return this.password;
+    }
+}

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
@@ -1,5 +1,6 @@
 package com.icegreen.greenmail.junit;
 
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailProxy;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -47,15 +48,22 @@ public class GreenMailRule extends GreenMailProxy implements MethodRule, TestRul
             @Override
             public void evaluate() throws Throwable {
                 greenMail = new GreenMail(serverSetups);
-                greenMail.start();
+                start();
                 try {
                     base.evaluate();
                 } finally {
-                    greenMail.stop();
+                    stop();
                 }
             }
 
         };
+    }
+
+    @Override
+    public GreenMailRule withConfiguration(GreenMailConfiguration config) {
+        // Just overriding to return more specific type
+        super.withConfiguration(config);
+        return this;
     }
 
     @Override

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -5,6 +5,8 @@
 package com.icegreen.greenmail.util;
 
 import com.icegreen.greenmail.Managers;
+import com.icegreen.greenmail.configuration.ConfiguredGreenMail;
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.imap.ImapServer;
 import com.icegreen.greenmail.pop3.Pop3Server;
 import com.icegreen.greenmail.smtp.SmtpManager;
@@ -20,7 +22,7 @@ import java.util.*;
 /**
  * Utility class that manages a greenmail server with support for multiple protocols
  */
-public class GreenMail implements GreenMailOperations {
+public class GreenMail extends ConfiguredGreenMail {
     private Managers managers;
     private Map<String, Service> services;
     private ServerSetup[] config;
@@ -36,7 +38,7 @@ public class GreenMail implements GreenMailOperations {
     /**
      * Call this constructor if you want to run one of the email servers only
      *
-     * @param config
+     * @param config  Server setup to use
      */
     public GreenMail(ServerSetup config) {
         this(new ServerSetup[]{config});
@@ -45,7 +47,7 @@ public class GreenMail implements GreenMailOperations {
     /**
      * Call this constructor if you want to run more than one of the email servers
      *
-     * @param config
+     * @param config Server setup to use
      */
     public GreenMail(ServerSetup[] config) {
         this.config = config;
@@ -88,6 +90,7 @@ public class GreenMail implements GreenMailOperations {
         if (!allup) {
             throw new RuntimeException("Couldnt start at least one of the mail services.");
         }
+        doConfigure();
     }
 
     @Override
@@ -261,6 +264,13 @@ public class GreenMail implements GreenMailOperations {
             String password = users.getProperty(email);
             setUser(email, email, password);
         }
+    }
+
+    @Override
+    public GreenMail withConfiguration(GreenMailConfiguration config) {
+        // Just overriding to return more specific type
+        super.withConfiguration(config);
+        return this;
     }
 
     public GreenMailUtil util() {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -239,7 +239,7 @@ public class GreenMail extends ConfiguredGreenMail {
 
     @Override
     public GreenMailUser setUser(String email, String login, String password) {
-        GreenMailUser user = managers.getUserManager().getUser(email);
+        GreenMailUser user = managers.getUserManager().getUser(login);
         if (null == user) {
             try {
                 user = managers.getUserManager().createUser(email, login, password);

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailProxy.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailProxy.java
@@ -1,6 +1,7 @@
 package com.icegreen.greenmail.util;
 
 import com.icegreen.greenmail.Managers;
+import com.icegreen.greenmail.configuration.ConfiguredGreenMail;
 import com.icegreen.greenmail.imap.ImapServer;
 import com.icegreen.greenmail.pop3.Pop3Server;
 import com.icegreen.greenmail.smtp.SmtpServer;
@@ -12,7 +13,7 @@ import java.util.Properties;
 /**
  * Proxy that routes all operations to an internal greenmail instance
  */
-public abstract class GreenMailProxy implements GreenMailOperations {
+public abstract class GreenMailProxy extends ConfiguredGreenMail {
     @Override
     public SmtpServer getSmtp() {
         return getGreenMail().getSmtp();
@@ -91,6 +92,8 @@ public abstract class GreenMailProxy implements GreenMailOperations {
     @Override
     public void start() {
         getGreenMail().start();
+        // Apply configuration that we store
+        doConfigure();
     }
 
     @Override

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/UserUtil.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/UserUtil.java
@@ -1,5 +1,7 @@
 package com.icegreen.greenmail.util;
 
+import com.icegreen.greenmail.base.GreenMailOperations;
+
 import javax.mail.internet.InternetAddress;
 
 /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
@@ -1,0 +1,23 @@
+package com.icegreen.greenmail.configuration;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetup;
+import org.junit.Test;
+
+import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBase.testUsersAccessibleConfig;
+
+/**
+ * Tests if the configuration is applied correctly to GreenMail instances.
+ */
+public class GreenMailConfigurationTest {
+    @Test
+    public void testUsersAccessible() {
+        GreenMail greenMail = new GreenMail(ServerSetup.IMAP).withConfiguration(
+                testUsersAccessibleConfig()
+        );
+        greenMail.start();
+        GreenMailConfigurationTestBase.testUsersAccessible(greenMail);
+        greenMail.stop();
+    }
+
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
@@ -1,7 +1,7 @@
 package com.icegreen.greenmail.configuration;
 
 import com.icegreen.greenmail.util.GreenMail;
-import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import org.junit.Test;
 
 import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBase.testUsersAccessibleConfig;
@@ -12,7 +12,7 @@ import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBas
 public class GreenMailConfigurationTest {
     @Test
     public void testUsersAccessible() {
-        GreenMail greenMail = new GreenMail(ServerSetup.IMAP).withConfiguration(
+        GreenMail greenMail = new GreenMail(ServerSetupTest.IMAP).withConfiguration(
                 testUsersAccessibleConfig()
         );
         greenMail.start();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTestBase.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTestBase.java
@@ -1,0 +1,44 @@
+package com.icegreen.greenmail.configuration;
+
+import com.icegreen.greenmail.base.GreenMailOperations;
+import com.icegreen.greenmail.util.Retriever;
+
+import javax.mail.Message;
+
+import static com.icegreen.greenmail.configuration.GreenMailConfiguration.aConfig;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test methods that are used in both GreenMailConfiguration tests
+ */
+public final class GreenMailConfigurationTestBase {
+    /**
+     * Util
+     */
+    private GreenMailConfigurationTestBase() {
+    }
+
+    /**
+     * Check if both user accounts can be accessed
+     */
+    public static void testUsersAccessible(GreenMailOperations greenMail) {
+        // Checks if the user that is registered in the config is actually accessible
+        final Retriever retriever = new Retriever(greenMail.getImap());
+        final Message[] messages = retriever.getMessages("user@localhost", "password");
+        // if getMessage is successful this means that the user account has been created
+        assertEquals(messages.length, 0);
+
+        // Now check second user. this one has a different user id
+        final Message[] messages2 = retriever.getMessages("secondUserLogin", "password2");
+        assertEquals(messages2.length, 0);
+    }
+
+    /**
+     * @return Configuration that has to be used for testUsersAccessible
+     */
+    public static GreenMailConfiguration testUsersAccessibleConfig() {
+        return aConfig()
+                .withUser("user@localhost", "password")
+                .withUser("secondUser@localhost", "secondUserLogin", "password2");
+    }
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
@@ -1,7 +1,7 @@
 package com.icegreen.greenmail.configuration;
 
 import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.ServerSetup;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -12,7 +12,7 @@ import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBas
  */
 public class GreenMailRuleConfigurationTest {
     @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetup.IMAP).withConfiguration(
+    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP).withConfiguration(
             testUsersAccessibleConfig()
     );
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
@@ -1,0 +1,24 @@
+package com.icegreen.greenmail.configuration;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.ServerSetup;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBase.testUsersAccessibleConfig;
+
+/**
+ * Tests that check if the GreenMailConfiguration is applied correctly to GreenMailRules
+ */
+public class GreenMailRuleConfigurationTest {
+    @Rule
+    public GreenMailRule greenMail = new GreenMailRule(ServerSetup.IMAP).withConfiguration(
+            testUsersAccessibleConfig()
+    );
+
+    @Test
+    public void testUsersAccessible() {
+        GreenMailConfigurationTestBase.testUsersAccessible(greenMail);
+    }
+
+}

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -11,6 +11,11 @@
     <title>Changes</title>
   </properties>
   <body>
+  <release version="1.5" date="2014-02-16" description="Changes for 1.5 release">
+    <action type="add">
+      Add GreenMailConfiguration that can be used to configure GreenMail istances (e.g. add users on startup)
+    </action>
+  </release>
   <release version="1.4" date="2014-10-29" description="Changes for 1.4 release">
     <action type="fix" issue="7">
       Do not try to add receiver addresses any more to MIME message. Handling of BCC addresses is now correct. BCC


### PR DESCRIPTION
Add possibility to create users using a configuration.
Add configuration.
Moved GreenMailOperations interface (technically a breaking API change but I doubt anyone uses the GreenMailOperation interface directly).
Add unit test for GreenMailConfiguration
Fixed bug where GreenMail creates user by email address and not by login

This PR replaces #60 

@marcelmay Please check and merge