### PR TITLE
Fixes #77: Handle lines with leading periods in SMTP server.

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MovingMessage.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MovingMessage.java
@@ -110,6 +110,8 @@ public class MovingMessage {
                 dataWriter.close();
 
                 break;
+            } else if (line.startsWith(".")) {
+                dataWriter.println(line.substring(1));
             } else {
                 dataWriter.println(line);
             }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/SmtpServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/SmtpServerTest.java
@@ -128,4 +128,14 @@ public class SmtpServerTest {
             assertEquals(i, gif[i]);
         }
     }
+
+    @Test
+    public void testSmtpServerLeadingPeriods() throws MessagingException {
+        String body = ". body with leading period";
+        GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com", "subject", body);
+        MimeMessage[] emails = greenMail.getReceivedMessages();
+        assertEquals(1, emails.length);
+        assertEquals("subject", emails[0].getSubject());
+        assertEquals(body, GreenMailUtil.getBody(emails[0]));
+    }
 }


### PR DESCRIPTION
Per http://tools.ietf.org/html/rfc5321#section-4.5.2:
If the first character is a period and there are other characters on the
line, the first character is deleted.