### PR TITLE
Resolves Issue-59

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
@@ -140,6 +140,8 @@ public interface GreenMailOperations {
 
     /**
      * Remove/purge all data from all mail stores (POP3/IMAP)
-     */
+    */
     void purgeEmailFromAllMailboxes() throws FolderException;
+
+
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
@@ -1,5 +1,7 @@
 package com.icegreen.greenmail.configuration;
 
+import com.icegreen.greenmail.user.UserManager;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,5 +47,10 @@ public class GreenMailConfiguration {
      */
     public List<UserBean> getUsersToCreate() {
         return usersToCreate;
+    }
+
+    public GreenMailConfiguration withDisabledAuthentication(UserManager userManager) {
+        userManager.setAuthRequired(false);
+        return this;
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/junit/GreenMailRule.java
@@ -76,5 +76,6 @@ public class GreenMailRule extends GreenMailProxy implements MethodRule, TestRul
     public void purgeEmailFromAllMailboxes() throws FolderException{
         greenMail.purgeEmailFromAllMailboxes();
     }
+
 }
 

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -310,4 +310,5 @@ public class GreenMail extends ConfiguredGreenMail {
     public GreenMailUtil util() {
         return GreenMailUtil.instance();
     }
+
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleDisableAuthenticationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleDisableAuthenticationTest.java
@@ -1,0 +1,54 @@
+package com.icegreen.greenmail.examples;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.Retriever;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.mail.Message;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Youssuf ElKalay.
+ * Example using GreenMailConfiguration to test authenticating against SMTP/IMAP/POP3 with no password required
+ */
+public class ExampleDisableAuthenticationTest {
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+
+    @Before
+    public void setup() {
+        greenMail.withConfiguration(new GreenMailConfiguration().withDisabledAuthentication(greenMail.getManagers().getUserManager()));
+    }
+
+    @Test
+    public void testNoAuthIMAP() {
+        Retriever retriever = new Retriever(greenMail.getImap());
+        try{
+            Message[] messages = retriever.getMessages("foo@localhost");
+            assertEquals(0, messages.length);
+        }   finally {
+            retriever.close();
+        }
+    }
+
+    @Test
+    public void testExistingUserNotRecreated() {
+        Retriever retriever = new Retriever(greenMail.getImap());
+        try{
+            Message[] messages = retriever.getMessages("foo@localhost");
+            assertEquals(0, messages.length);
+            assertThat(greenMail.getManagers().getUserManager().userExists("foo@localhost"),equalTo(true));
+        }   finally {
+            retriever.close();
+        }
+
+
+    }
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
@@ -3,10 +3,12 @@ package com.icegreen.greenmail.user;
 import com.icegreen.greenmail.imap.ImapHostManager;
 import com.icegreen.greenmail.imap.ImapHostManagerImpl;
 import com.icegreen.greenmail.store.InMemoryStore;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class UserManagerTest {
     @Test
@@ -55,5 +57,51 @@ public class UserManagerTest {
 
         userManager.deleteUser(user);
         assertTrue(userManager.listUser().isEmpty());
+    }
+
+    @Test
+    public void testNoAuthRequired() {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        userManager.setAuthRequired(false);
+
+        assertTrue(userManager.listUser().isEmpty());
+        assertTrue(userManager.test("foo@localhost",null));
+
+    }
+
+    @Test
+    public void testNoAuthRequiredWithExistingUser() throws UserException {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        userManager.setAuthRequired(false);
+
+        userManager.createUser("foo@example.com","foo",null);
+        assertFalse(userManager.listUser().isEmpty());
+        assertTrue(userManager.test("foo",null));
+
+    }
+
+    @Test
+    public void testAuthRequired() {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        userManager.setAuthRequired(true);
+
+        assertTrue(userManager.listUser().isEmpty());
+        assertFalse(userManager.test("foo@localhost",null));
+
+    }
+
+    @Test
+    public void testAuthRequiredWithExistingUser() throws UserException {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        userManager.setAuthRequired(true);
+        userManager.createUser("foo@example.com","foo","bar");
+
+        assertFalse(userManager.listUser().isEmpty());
+        assertTrue(userManager.test("foo","bar"));
+
     }
 }


### PR DESCRIPTION
Added functionality to implement the following:
Allow SMTP/IMAP/POP3 connections using accounts with any password
If an user account doesn't exist when connecting via SMTP/POP3/IMAP - create an account and return an empty mailbox.