### PR TITLE
Fixes #152 : Misspelled getReceviedMessagesForDomain method

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/base/GreenMailOperations.java
@@ -76,11 +76,19 @@ public interface GreenMailOperations {
     MimeMessage[] getReceivedMessages();
 
     /**
+     * @deprecated Use {@link #getReceivedMessagesForDomain(String domain)} instead.
+     *
+     * @param domain returns all received messages arrived to domain.
+     */
+    @Deprecated
+    MimeMessage[] getReceviedMessagesForDomain(String domain);
+
+    /**
      * This method can be used as an easy 'catch-all' mechanism.
      *
-     * @param domain returns all receved messages arrived to domain.
+     * @param domain returns all received messages arrived to domain.
      */
-    MimeMessage[] getReceviedMessagesForDomain(String domain);
+    MimeMessage[] getReceivedMessagesForDomain(String domain);
 
     /**
      * Sets the password for the account linked to email. If no account exits, one is automatically created when an email is received

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -235,8 +235,17 @@ public class GreenMail extends ConfiguredGreenMail {
         return ret;
     }
 
+    /**
+     * @deprecated Use {@link #getReceivedMessagesForDomain(String domain)} instead.
+     */
+    @Deprecated
     @Override
     public MimeMessage[] getReceviedMessagesForDomain(String domain) {
+        return getReceivedMessagesForDomain(domain);
+    }
+
+    @Override
+    public MimeMessage[] getReceivedMessagesForDomain(String domain) {
         List<StoredMessage> msgs = managers.getImapHostManager().getAllMessages();
         List<MimeMessage> ret = new ArrayList<>();
         try {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailProxy.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailProxy.java
@@ -65,9 +65,18 @@ public abstract class GreenMailProxy extends ConfiguredGreenMail {
         return getGreenMail().getReceivedMessages();
     }
 
+    /**
+     * @deprecated Use {@link #getReceivedMessagesForDomain(String domain)} instead.
+     */
+    @Deprecated
     @Override
     public MimeMessage[] getReceviedMessagesForDomain(String domain) {
-        return getGreenMail().getReceviedMessagesForDomain(domain);
+        return getReceivedMessagesForDomain(domain);
+    }
+
+    @Override
+    public MimeMessage[] getReceivedMessagesForDomain(String domain) {
+        return getGreenMail().getReceivedMessagesForDomain(domain);
     }
 
     @Override

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleJavaMailTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleJavaMailTest.java
@@ -54,8 +54,8 @@ public class ExampleJavaMailTest {
         assertEquals(msg.getSubject(), msgReceived.getSubject());
 
         // Alternative 3: ... directly fetch sent message using GreenMail API
-        assertEquals(1, greenMail.getReceviedMessagesForDomain("bar@example.com").length);
-        msgReceived = greenMail.getReceviedMessagesForDomain("bar@example.com")[0];
+        assertEquals(1, greenMail.getReceivedMessagesForDomain("bar@example.com").length);
+        msgReceived = greenMail.getReceivedMessagesForDomain("bar@example.com")[0];
         assertEquals(msg.getSubject(), msgReceived.getSubject());
 
         store.close();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/CatchAllTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/CatchAllTest.java
@@ -28,8 +28,8 @@ public class CatchAllTest {
         GreenMailUtil.sendTextEmailTest("to32@domain3.com", "from@localhost.com", "subject", "body");
         GreenMailUtil.sendTextEmailTest("to33@domain3.com", "from@localhost.com", "subject", "body");
         assertEquals(6, greenMail.getReceivedMessages().length);
-        assertEquals(2, greenMail.getReceviedMessagesForDomain("domain1.com").length);
-        assertEquals(1, greenMail.getReceviedMessagesForDomain("domain2.com").length);
-        assertEquals(3, greenMail.getReceviedMessagesForDomain("domain3.com").length);
+        assertEquals(2, greenMail.getReceivedMessagesForDomain("domain1.com").length);
+        assertEquals(1, greenMail.getReceivedMessagesForDomain("domain2.com").length);
+        assertEquals(3, greenMail.getReceivedMessagesForDomain("domain3.com").length);
     }
 }

--- a/greenmail-site/index.html
+++ b/greenmail-site/index.html
@@ -418,8 +418,8 @@ public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IM
     ...
 
     // Alternative 3: ... directly fetch sent message using GreenMail API
-    assertEquals(1, greenMail.getReceviedMessagesForDomain("bar@example.com").length);
-    msgReceived = greenMail.getReceviedMessagesForDomain("bar@example.com")[0];
+    assertEquals(1, greenMail.getReceivedMessagesForDomain("bar@example.com").length);
+    msgReceived = greenMail.getReceivedMessagesForDomain("bar@example.com")[0];
     ...
 }
         </code></pre><!-- @formatter:on -->


### PR DESCRIPTION
Deprecated misspelled getReceviedMessagesForDomain method in favor of correctly spelled getReceivedMessagesForDomain in GreenMailOperations interface and its implementing classes.