### PR TITLE
Handle missing subject headers.

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -126,7 +126,10 @@ public class SimpleMessageAttributes
         // Section 1 - Message Headers
         if (part instanceof MimeMessage) {
             try {
-                subject = part.getHeader("Subject")[0];
+                String[] subjects = part.getHeader("Subject");
+                if ((subjects != null) && (subjects.length > 0)) {
+                    subject = subjects[0];
+                }
             } catch (MessagingException me) {
 //                if (DEBUG) getLogger().debug("Messaging Exception for getSubject: " + me);
             }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
@@ -20,11 +20,4 @@ public class ExampleSendTest {
                 "some subject", "some body"); // --- Place your sending code here instead
         assertEquals("some body", GreenMailUtil.getBody(greenMail.getReceivedMessages()[0]));
     }
-
-    @Test
-    public void testSendWithoutSubject() throws MessagingException {
-        GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com",
-                null, "some subjectless body"); // --- Place your sending code here instead
-        assertEquals("some subjectless body", GreenMailUtil.getBody(greenMail.getReceivedMessages()[0]));
-    }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
@@ -20,4 +20,11 @@ public class ExampleSendTest {
                 "some subject", "some body"); // --- Place your sending code here instead
         assertEquals("some body", GreenMailUtil.getBody(greenMail.getReceivedMessages()[0]));
     }
+
+    @Test
+    public void testSendWithoutSubject() throws MessagingException {
+        GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com",
+                null, "some subjectless body"); // --- Place your sending code here instead
+        assertEquals("some subjectless body", GreenMailUtil.getBody(greenMail.getReceivedMessages()[0]));
+    }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/specificmessages/SenderRecipientTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/specificmessages/SenderRecipientTest.java
@@ -84,6 +84,13 @@ public class SenderRecipientTest {
         }
     }
 
+    @Test
+    public void testSendWithoutSubject() throws MessagingException {
+        GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com",
+                null, "some subjectless body");
+        assertEquals("some subjectless body", GreenMailUtil.getBody(greenMail.getReceivedMessages()[0]));
+    }
+
     /**
      * Retrieve mail through IMAP and POP3 and check sender and receivers
      *


### PR DESCRIPTION
When the incoming message doesn't have a Subject header, a NullPointerException is thrown and the rest of the processing fails.