### PR TITLE
FetchCommand: format INTERNALDATE correctly

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -9,6 +9,7 @@ package com.icegreen.greenmail.store;
 
 import com.icegreen.greenmail.mail.MailAddress;
 import com.icegreen.greenmail.util.GreenMailUtil;
+import com.sun.mail.imap.protocol.INTERNALDATE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public class SimpleMessageAttributes
 
         if(null != receivedDate) {
             this.receivedDate = receivedDate;
-            receivedDateString = new MailDateFormat().format(receivedDate);
+            receivedDateString = INTERNALDATE.format(receivedDate);
         }
         if(null != sentDate) {
             sentDateEnvelopeString = new MailDateFormat().format(sentDate);


### PR DESCRIPTION
This fixes a TODO in the `FetchCommand` to format the output of the `INTERNALDATE` in a more standard way. I could not find any documentation of this format in any IMAP RFCs, but this format matches python's [`imaplib`](https://docs.python.org/2/library/imaplib.html#imaplib.Time2Internaldate) and is similar to javamail's (but includes the timezone). 

Access to the `SimpleDateFormat` is synchronized because `SimpleDateFormat` is not thread safe, but we could instead create new instances of `SimpleDateFormat` every time we need it.