### PR TITLE
Fixes ArrayIndexOutOfBoundsException in FetchCommand

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
@@ -80,7 +80,7 @@ class FetchCommand extends SelectedStateCommand implements UidEnabledCommand {
 
         // a wildcard search must include the last message if the folder is not empty,
         // as per https://tools.ietf.org/html/rfc3501#section-6.4.8
-        long lastMessageUid = uids[uids.length - 1];
+        long lastMessageUid = uids.length > 0 ? uids[uids.length - 1] : -1L;
         if (mailbox.getMessageCount() > 0 && includes(idSet, Long.MAX_VALUE) && !includes(idSet, lastMessageUid)) {
             String msgData = getMessageData(useUids, fetch, mailbox, lastMessageUid);
             response.fetchResponse(mailbox.getMsn(lastMessageUid), msgData);


### PR DESCRIPTION
Fixes an ArrayIndexOutOfBoundsException thrown when getting a message for an unknown UID in an empty INBOX.