### PR TITLE
Issue #213: Amended address parsing to handle personal commas

### DIFF
--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/GreenMailUtilTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/GreenMailUtilTest.java
@@ -91,7 +91,7 @@ public class GreenMailUtilTest {
         try {
             greenMail.setUser("foo@localhost", "pwd");
             greenMail.start();
-            GreenMailUtil.sendTextEmail("foo@localhost", "bar@localhost",
+            GreenMailUtil.sendTextEmail("\"Foo, Bar\" <foo@localhost>", "\"Bar, Foo\" <bar@localhost>",
                     "Test subject", "Test message", ServerSetupTest.SMTP);
             greenMail.waitForIncomingEmail(1);
 
@@ -106,10 +106,10 @@ public class GreenMailUtilTest {
                 assertEquals("Test subject", m.getSubject());
                 Address a[] = m.getRecipients(Message.RecipientType.TO);
                 assertTrue(null != a && a.length == 1
-                        && a[0].toString().equals("foo@localhost"));
+                        && a[0].toString().equals("\"Foo, Bar\" <foo@localhost>"));
                 a = m.getFrom();
                 assertTrue(null != a && a.length == 1
-                        && a[0].toString().equals("bar@localhost"));
+                        && a[0].toString().equals("\"Bar, Foo\" <bar@localhost>"));
                 assertTrue(m.getContentType().toLowerCase()
                         .startsWith("text/plain"));
                 assertEquals("Test message", m.getContent());


### PR DESCRIPTION
This is somewhat a breaking change in that invalid email addresses are no longer ignored, but a starting point for discussion.

Using InternetAddress.parse simplifies the parsing of rfc822 addresses so we don't have to pull in additional 3rd party libraries or complicated regex logic to tokenize quotes commas.