### PR TITLE
made createMultipartWithAttachment public

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailUtil.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailUtil.java
@@ -321,7 +321,7 @@ public class GreenMailUtil {
      * @param description Description of the attachment
      * @return New multipart
      */
-    private static MimeMultipart createMultipartWithAttachment(String msg, final byte[] attachment, final String contentType,
+    public static MimeMultipart createMultipartWithAttachment(String msg, final byte[] attachment, final String contentType,
                                                                final String filename, String description) {
         try {
             MimeMultipart multiPart = new MimeMultipart();


### PR DESCRIPTION
It can be useful to have the method to create multipart for attachment mails public, e.g. for testing parsing of mail attachments.