### PR TITLE
Implementation of SentDateTerm/ReceivedDateTerm

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchKey.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchKey.java
@@ -96,7 +96,10 @@ public enum SearchKey {
      * to the specified message sequence number set.
      */
     SEQUENCE_SET(1),
-    OR(2);
+    OR(2),
+    SINCE(1),
+    ON(1),
+    BEFORE(1);
 
     private int minArgs = 0; // expected additional arguments
     private boolean operator = false; // Is an operator, such as AND, OR, NOT ...

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchKey.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchKey.java
@@ -99,7 +99,10 @@ public enum SearchKey {
     OR(2),
     SINCE(1),
     ON(1),
-    BEFORE(1);
+    BEFORE(1),
+    SENTSINCE(1),
+    SENTON(1),
+    SENTBEFORE(1);
 
     private int minArgs = 0; // expected additional arguments
     private boolean operator = false; // Is an operator, such as AND, OR, NOT ...

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import javax.mail.Flags;
 import javax.mail.Message;
@@ -174,13 +175,14 @@ public abstract class SearchTermBuilder {
     }
 
     private static Date parseDate(List<String> parameters) {
-        DateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
+        DateFormat df = new SimpleDateFormat("dd-MMM-yyyy", Locale.ENGLISH);
+        String date = parameters.get(0);
         try {
-            Date d = df.parse(parameters.get(0));
+            Date d = df.parse(date);
             LOGGER.debug("Using date '{}'.", d);
             return d;
         } catch (ParseException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException("Unable to parse date '" + date+"'",e);
         }
     }
 	private static SearchTermBuilder createORTermBuilder() {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
@@ -24,6 +24,7 @@ import javax.mail.search.ReceivedDateTerm;
 import javax.mail.search.RecipientStringTerm;
 import javax.mail.search.RecipientTerm;
 import javax.mail.search.SearchTerm;
+import javax.mail.search.SentDateTerm;
 import javax.mail.search.SubjectTerm;
 
 import org.slf4j.Logger;
@@ -138,6 +139,15 @@ public abstract class SearchTermBuilder {
             case BEFORE:
                 builder = createReceivedDateTermBuilder(ComparisonTerm.LT);
                 break;
+            case SENTSINCE:
+                builder = createSentDateTermBuilder(ComparisonTerm.GE);
+                break;
+            case SENTON:
+                builder = createSentDateTermBuilder(ComparisonTerm.EQ);
+                break;
+            case SENTBEFORE:
+                builder = createSentDateTermBuilder(ComparisonTerm.LT);
+                break;             
             default:
                 throw new IllegalStateException("Unsupported search term '" + key + '\'');
         }
@@ -145,23 +155,34 @@ public abstract class SearchTermBuilder {
         return builder;
     }
 
-    private static SearchTermBuilder createReceivedDateTermBuilder(final int searchTerm) {
-
+    private static SearchTermBuilder createSentDateTermBuilder(final int searchTerm) {
         return new SearchTermBuilder() {
             @Override
             public SearchTerm build() {
-                try {
-                    DateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
-                    Date d = df.parse(getParameters().get(0));
-                    LOGGER.debug("Using search term '{}' for date '{}'.", searchTerm, d);
-                    return new ReceivedDateTerm(searchTerm, d);
-                } catch (ParseException e) {
-                    throw new RuntimeException(e);
-                }
+                return new SentDateTerm(searchTerm, parseDate(getParameters()));
             }
         };
     }
-    
+
+    private static SearchTermBuilder createReceivedDateTermBuilder(final int searchTerm) {
+        return new SearchTermBuilder() {
+            @Override
+            public SearchTerm build() {
+                return new ReceivedDateTerm(searchTerm, parseDate(getParameters()));
+            }
+        };
+    }
+
+    private static Date parseDate(List<String> parameters) {
+        DateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
+        try {
+            Date d = df.parse(parameters.get(0));
+            LOGGER.debug("Using date '{}'.", d);
+            return d;
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
 	private static SearchTermBuilder createORTermBuilder() {
 			 return new SearchTermBuilder() {
 	            @Override

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
@@ -182,7 +182,7 @@ public abstract class SearchTermBuilder {
             LOGGER.debug("Using date '{}'.", d);
             return d;
         } catch (ParseException e) {
-            throw new IllegalStateException("Unable to parse date '" + date+"'",e);
+            throw new IllegalArgumentException("Unable to parse date '" + date+"'",e);
         }
     }
 	private static SearchTermBuilder createORTermBuilder() {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchTermBuilder.java
@@ -1,18 +1,35 @@
 package com.icegreen.greenmail.imap.commands;
 
-import com.icegreen.greenmail.store.StoredMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
 import javax.mail.Flags;
 import javax.mail.Message;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
-import javax.mail.search.*;
+import javax.mail.search.AndTerm;
+import javax.mail.search.BodyTerm;
+import javax.mail.search.ComparisonTerm;
+import javax.mail.search.FlagTerm;
+import javax.mail.search.FromStringTerm;
+import javax.mail.search.FromTerm;
+import javax.mail.search.HeaderTerm;
+import javax.mail.search.OrTerm;
+import javax.mail.search.ReceivedDateTerm;
 import javax.mail.search.RecipientStringTerm;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import javax.mail.search.RecipientTerm;
+import javax.mail.search.SearchTerm;
+import javax.mail.search.SubjectTerm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.icegreen.greenmail.store.StoredMessage;
 
 /**
  * Builder for search terms.
@@ -22,13 +39,15 @@ import java.util.List;
 public abstract class SearchTermBuilder {
     private SearchKey key;
     private List<String> parameters = Collections.<String>emptyList();
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchTermBuilder.class);
+    
     public static SearchTermBuilder create(final String pTerm) {
         return create(SearchKey.valueOf(pTerm));
     }
 
     public static SearchTermBuilder create(final SearchKey key) {
         SearchTermBuilder builder;
+        LOGGER.debug("Creating search term for '{}'", key);
         switch (key) {
             // Non flags first
             case HEADER:
@@ -110,11 +129,37 @@ public abstract class SearchTermBuilder {
             case OR:
                 builder = createORTermBuilder();
                 break;
+            case SINCE:
+                builder = createReceivedDateTermBuilder(ComparisonTerm.GE);
+                break;
+            case ON:
+                builder = createReceivedDateTermBuilder(ComparisonTerm.EQ);
+                break;
+            case BEFORE:
+                builder = createReceivedDateTermBuilder(ComparisonTerm.LT);
+                break;
             default:
                 throw new IllegalStateException("Unsupported search term '" + key + '\'');
         }
         builder.setSearchKey(key);
         return builder;
+    }
+
+    private static SearchTermBuilder createReceivedDateTermBuilder(final int searchTerm) {
+
+        return new SearchTermBuilder() {
+            @Override
+            public SearchTerm build() {
+                try {
+                    DateFormat df = new SimpleDateFormat("dd-MMM-yyyy");
+                    Date d = df.parse(getParameters().get(0));
+                    LOGGER.debug("Using search term '{}' for date '{}'.", searchTerm, d);
+                    return new ReceivedDateTerm(searchTerm, d);
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
     }
     
 	private static SearchTermBuilder createORTermBuilder() {
@@ -402,4 +447,5 @@ public abstract class SearchTermBuilder {
             }
         }
     }
+
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/StoredMessage.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/StoredMessage.java
@@ -6,10 +6,11 @@
  */
 package com.icegreen.greenmail.store;
 
+import java.util.Date;
+
 import javax.mail.Flags;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
-import java.util.Date;
 
 /**
  * A mail message with all of the extra stuff that IMAP requires.
@@ -33,9 +34,17 @@ public class StoredMessage {
      */
     public static class UidAwareMimeMessage extends MimeMessage {
         private long uid;
-        public UidAwareMimeMessage(MimeMessage source, long uid) throws MessagingException {
+        private Date receivedDate;
+
+        public UidAwareMimeMessage(MimeMessage source, long uid, Date receivedDate) throws MessagingException {
             super(source);
             this.uid = uid;
+            this.receivedDate = receivedDate;
+        }
+
+        @Override
+        public Date getReceivedDate() {
+            return receivedDate;
         }
 
         /**
@@ -56,11 +65,11 @@ public class StoredMessage {
     }
 
     StoredMessage(MimeMessage mimeMessage,
-                  Date receivedDate, long uid) {
+            Date receivedDate, long uid) {
         this.receivedDate = receivedDate;
         this.uid = uid;
         try {
-            this.mimeMessage = new UidAwareMimeMessage(mimeMessage, uid);
+            this.mimeMessage = new UidAwareMimeMessage(mimeMessage, uid, receivedDate);
             this.attributes = new SimpleMessageAttributes(mimeMessage, receivedDate);
         } catch (MessagingException e) {
             throw new IllegalStateException("Could not parse mime message " + mimeMessage + " with uid " + uid, e);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
@@ -4,6 +4,7 @@
  */
 package com.icegreen.greenmail.test.commands;
 
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -34,6 +35,7 @@ import javax.mail.search.SubjectTerm;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.icegreen.greenmail.imap.commands.SearchKey;
 import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
@@ -203,6 +205,17 @@ public class ImapSearchTest {
         testDateTerm(imapFolder, new ReceivedDateTerm(ComparisonTerm.LT, getSampleDate(2)), m[4]);
         //TODO: less equals: does not work yet, is therefore not included, should only return sample mail
         //testDateTerm(imapFolder, new ReceivedDateTerm(ComparisonTerm.LE, getSampleDate(2)), m[4]);
+    }
+
+    // Test an unsupported search term for exception. Should be ignored.
+    @Test
+    public void testUnsupportedSearchWarnsButDoesNotThrowException() throws MessagingException {
+        try {
+            SearchKey.valueOf("SENTDATE");
+            fail("Expected IAE for unimplemented search");
+        } catch (IllegalArgumentException ex) {
+            // Expected
+        }
     }
 
     private Date getSampleDate(int day) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
@@ -189,6 +189,7 @@ public class ImapSearchTest {
         //less than (sample mail + 1 day), only returns sample mail
         testDateTerm(imapFolder, new SentDateTerm(ComparisonTerm.LT, getSampleDate(2)), m[5]);
         //TODO: less equals: does not work yet, is therefore not included, should only return sample mail
+        //see https://github.com/greenmail-mail-test/greenmail/issues/234
         //testDateTerm(imapFolder, new SentDateTerm(ComparisonTerm.LE, getSampleDate(2)), m[5]);
     }
 
@@ -204,6 +205,7 @@ public class ImapSearchTest {
         //less than (sample mail + 1 day), only returns sample mail
         testDateTerm(imapFolder, new ReceivedDateTerm(ComparisonTerm.LT, getSampleDate(2)), m[4]);
         //TODO: less equals: does not work yet, is therefore not included, should only return sample mail
+        //see https://github.com/greenmail-mail-test/greenmail/issues/234
         //testDateTerm(imapFolder, new ReceivedDateTerm(ComparisonTerm.LE, getSampleDate(2)), m[4]);
     }
 


### PR DESCRIPTION
Hi there,

this is my pull request for the received date filter implementation as several keywords have not been implemented yet. 5 out of 6 comparison types work, except for LESS THAN:
```
IMAP Line received : <A38 SEARCH OR BEFORE 2-Feb-2010 ON 2-Feb-2010 ALL\r\n>
```
Using less than creates an OR with an ALL statement which currently leads to combine "before" and "on" with an conjunction, effectively dropping the "OR" keyword:

https://github.com/greenmail-mail-test/greenmail/blob/2248d0f1f8b512e370d5762307cba48952e3afaa/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchCommandParser.java#L150-L153

As I'm not sure if this is a parsing issue or a search statement creation issue, I'd be happy for some feedback. The not working test is currently commented, but already exists in the code.

Regards,
Niko