### PR TITLE
Make JUnit dependency optional.

### DIFF
--- a/greenmail-core/pom.xml
+++ b/greenmail-core/pom.xml
@@ -33,6 +33,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
+      <optional>true</optional>
       <!-- We only need the API in compile scope. Matchers are needed in test scope -->
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Alternative solution to the one proposed in https://github.com/greenmail-mail-test/greenmail/pull/226

By making the dependency optional users have to add it explicitly. Therefore people not using JUnit won't have the dependency. Current users of  `GreenMailRule` should have JUnit on the classpath anyway and should not have to change anything (like adding a new green-mail-test dependency).