### PR TITLE
Fixed command continuation request not getting recognised

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapRequestLineReader.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapRequestLineReader.java
@@ -173,6 +173,9 @@ public class ImapRequestLineReader {
             throws ProtocolException {
         try {
             output.write('+');
+            output.write(' ');
+            output.write('O');
+            output.write('K');
             output.write('\r');
             output.write('\n');
             output.flush();


### PR DESCRIPTION
Hi, I was working with the NGINX Imap Proxy and used greenmail to debug the login.
I just got Timeouts and after doing some digging noticed the command continuation request sould contain some text after the 2 "+", though it very vagely stated in the RFC.

After adding the " Ok" NGINX recognised the request.