### PR TITLE
Use exec to replace bash process with java process

### DIFF
--- a/greenmail-docker/standalone/run_greenmail.sh
+++ b/greenmail-docker/standalone/run_greenmail.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 echo "Executing 'java $JAVA_OPTS $GREENMAIL_OPTS -jar greenmail-standalone.jar' ..."
-java $JAVA_OPTS $GREENMAIL_OPTS -jar greenmail-standalone.jar
+exec java $JAVA_OPTS $GREENMAIL_OPTS -jar greenmail-standalone.jar


### PR DESCRIPTION
To handle signals better it is good practice to let the last command replace the bash script via `exec` command. See also http://veithen.io/2014/11/16/sigterm-propagation.html
