### PR TITLE
#291 - MailCommand param pattern too greedy for outlook.com

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/MailCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/MailCommand.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
  */
 public class MailCommand
         extends SmtpCommand {
-    static final Pattern PARAM = Pattern.compile("MAIL FROM:\\s?<(.*)>",
+    static final Pattern PARAM = Pattern.compile("MAIL FROM:\\s?<([^>]*)>.*",
             Pattern.CASE_INSENSITIVE);
 
     @Override

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/SMTPCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/SMTPCommandTest.java
@@ -92,4 +92,26 @@ public class SMTPCommandTest {
             }
         }
     }
+
+    @Test
+    public void mailSenderAUTHSuffix() throws IOException, MessagingException {
+        Socket smtpSocket;
+        String hostAddress = greenMail.getSmtp().getBindTo();
+        int port = greenMail.getSmtp().getPort();
+
+        Session smtpSession = greenMail.getSmtp().createSession();
+        URLName smtpURL = new URLName(hostAddress);
+        SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL);
+
+        try {
+            smtpSocket = new Socket(hostAddress, port);
+            smtpTransport.connect(smtpSocket);
+            assertThat(smtpTransport.isConnected(), is(equalTo(true)));
+            smtpTransport.issueCommand("MAIL FROM: <test.test@test.net> AUTH <>", -1);
+            assertThat("250 OK", equalToIgnoringWhiteSpace(smtpTransport.getLastServerResponse()));
+        } finally {
+            smtpTransport.close();
+        }
+    }
+
 }


### PR DESCRIPTION
changed PARAM pattern to extract domain correctly
added tests to check correct extraction by MailCommand