### PR TITLE
Fix Content-Disposition: inline not reported without parameters

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -666,15 +666,16 @@ public class SimpleMessageAttributes
 
         @Override
         public String toString() {
+            // https://tools.ietf.org/html/rfc3501#section-9 body-fld-dsp
             StringBuilder ret = new StringBuilder();
             if (null == params) {
                 ret.append(Q).append(value).append(Q);
             } else {
+                ret.append(LB);
+                ret.append(Q).append(value).append(Q + SP);
                 if (params.isEmpty()) {
                     ret.append(NIL);
                 } else {
-                    ret.append(LB);
-                    ret.append(Q).append(value).append(Q + SP);
                     ret.append(LB);
                     int i = 0;
                     for (String param : params) {
@@ -684,8 +685,8 @@ public class SimpleMessageAttributes
                         ret.append(param);
                     }
                     ret.append(RB);
-                    ret.append(RB);
                 }
+                ret.append(RB);
             }
             return ret.toString();
         }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendReceiveMessageWithInlineAttachmentTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendReceiveMessageWithInlineAttachmentTest.java
@@ -52,6 +52,7 @@ public class ExampleSendReceiveMessageWithInlineAttachmentTest {
 
         final BodyPart bodyPart = part.getBodyPart(0);
         assertEquals("TEXT/PLAIN; charset=us-ascii", bodyPart.getContentType());
+        assertEquals("inline", bodyPart.getDisposition());
         Assert.assertEquals("This is some text to be displayed inline", bodyPart.getContent());
     }
 


### PR DESCRIPTION
When retrieving a message with a part with `Content-Disposition: inline` header (so no parameters) from IMAP, the resulting `MimeMessage` will not have a `Content-Disposition` header in that part.

The change done for #113 (6bd221c) will report NIL for the entire Content-Disposition if there are no parameters, instead of NIL for the parameter list. As a result, the `Content-Disposition` is not set in the part. See also RFC 3051 section 9, syntax rule body-fld-dsp.

If possible, I'd love to get this into 1.5.x as well. If you want me to write a pull request to the release/1.5.x branch as well, let me know.