### PR TITLE
Doesn't check POP password when logging in with -Dgreenmail.auth.disa…

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/Pop3State.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/Pop3State.java
@@ -52,7 +52,9 @@ public class Pop3State {
         if (user == null)
             throw new UserException("No user selected");
 
-        user.authenticate(pass);
+        if (manager.isAuthRequired()) {
+            user.authenticate(pass);
+        }
         inbox = imapHostManager.getInbox(user);
     }
 

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
@@ -6,12 +6,16 @@
  */
 package com.icegreen.greenmail.user;
 
-import com.icegreen.greenmail.imap.ImapHostManager;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import com.icegreen.greenmail.imap.ImapHostManager;
 
 public class UserManager {
     private static final Logger log = LoggerFactory.getLogger(UserManager.class);
@@ -65,7 +69,7 @@ public class UserManager {
         GreenMailUser u = getUser(userId);
 
         if (!authRequired) {
-            if(null == u) { // Auto create user
+            if (null == u) { // Auto create user
                 try {
                     createUser(userId, userId, password);
                 } catch (UserException e) {
@@ -86,6 +90,10 @@ public class UserManager {
 
     public void setAuthRequired(boolean auth) {
         authRequired = auth;
+    }
+
+    public boolean isAuthRequired() {
+        return authRequired;
     }
 
     public ImapHostManager getImapHostManager() {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/AuthenticationDisabledTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/AuthenticationDisabledTest.java
@@ -1,69 +1,100 @@
 package com.icegreen.greenmail.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
+
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
 import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.pop3.Pop3State;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.user.UserException;
+import com.icegreen.greenmail.user.UserImpl;
+import com.icegreen.greenmail.user.UserManager;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class AuthenticationDisabledTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup[]{ServerSetupTest.SMTP, ServerSetupTest.IMAP})
-            .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
+	@Rule
+	public final GreenMailRule greenMail = new GreenMailRule(
+			new ServerSetup[] { ServerSetupTest.SMTP, ServerSetupTest.IMAP })
+					.withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
 
-    @Test
-    public void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
-        final String to = "to@localhost";
-        final String subject = "subject";
-        final String body = "body";
-        GreenMailUtil.sendTextEmailTest(to, "from@localhost", subject, body);
-        MimeMessage[] emails = greenMail.getReceivedMessages();
-        assertEquals(1, emails.length);
-        assertEquals(subject, emails[0].getSubject());
-        assertEquals(body, GreenMailUtil.getBody(emails[0]));
+	@Test
+	public void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
+		final String to = "to@localhost";
+		final String subject = "subject";
+		final String body = "body";
+		GreenMailUtil.sendTextEmailTest(to, "from@localhost", subject, body);
+		MimeMessage[] emails = greenMail.getReceivedMessages();
+		assertEquals(1, emails.length);
+		assertEquals(subject, emails[0].getSubject());
+		assertEquals(body, GreenMailUtil.getBody(emails[0]));
 
-        greenMail.waitForIncomingEmail(5000, 1);
+		greenMail.waitForIncomingEmail(5000, 1);
 
-        try (Retriever retriever = new Retriever(greenMail.getImap())) {
-            Message[] messages = retriever.getMessages(to);
-            assertEquals(1, messages.length);
-            assertEquals(subject, messages[0].getSubject());
-            assertEquals(body, messages[0].getContent());
-        }
-    }
+		try (Retriever retriever = new Retriever(greenMail.getImap())) {
+			Message[] messages = retriever.getMessages(to);
+			assertEquals(1, messages.length);
+			assertEquals(subject, messages[0].getSubject());
+			assertEquals(body, messages[0].getContent());
+		}
+	}
 
-    @Test
-    public void testReceiveWithAuthDisabled() {
-        final String to = "to@localhost";
+	@Test
+	public void testReceiveWithAuthDisabled() {
+		final String to = "to@localhost";
 
-        greenMail.waitForIncomingEmail(500, 1);
+		greenMail.waitForIncomingEmail(500, 1);
 
-        try (Retriever retriever = new Retriever(greenMail.getImap())) {
-            Message[] messages = retriever.getMessages(to);
-            assertEquals(0, messages.length);
-        }
-    }
+		try (Retriever retriever = new Retriever(greenMail.getImap())) {
+			Message[] messages = retriever.getMessages(to);
+			assertEquals(0, messages.length);
+		}
+	}
 
-    @Test
-    public void testReceiveWithAuthDisabledAndProvisionedUser() {
-        final String to = "to@localhost";
-        greenMail.setUser(to,"to","secret");
+	@Test
+	public void testReceiveWithAuthDisabledAndProvisionedUser() {
+		final String to = "to@localhost";
+		greenMail.setUser(to, "to", "secret");
 
-        greenMail.waitForIncomingEmail(500, 1);
+		greenMail.waitForIncomingEmail(500, 1);
 
-        try (Retriever retriever = new Retriever(greenMail.getImap())) {
-            Message[] messages = retriever.getMessages(to);
-            assertEquals(0, messages.length);
-        }
-    }
+		try (Retriever retriever = new Retriever(greenMail.getImap())) {
+			Message[] messages = retriever.getMessages(to);
+			assertEquals(0, messages.length);
+		}
+	}
+
+	@Test
+	public void testPop3ConnectNoAuth() throws MessagingException, UserException, FolderException {
+		UserManager userManager = greenMail.getManagers().getUserManager();
+		Pop3State status = new Pop3State(userManager);
+		userManager.setAuthRequired(false);
+
+		UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
+		status.setUser(user);
+		status.authenticate("pass");
+	}
+
+	@Test(expected = UserException.class)
+	public void testPop3ConnectAuth() throws MessagingException, UserException, FolderException {
+		UserManager userManager = greenMail.getManagers().getUserManager();
+		Pop3State status = new Pop3State(userManager);
+		userManager.setAuthRequired(true);
+
+		UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
+		status.setUser(user);
+		status.authenticate("pass");
+	}
+
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/AuthenticationDisabledTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/AuthenticationDisabledTest.java
@@ -24,77 +24,77 @@ import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
 
 public class AuthenticationDisabledTest {
-	@Rule
-	public final GreenMailRule greenMail = new GreenMailRule(
-			new ServerSetup[] { ServerSetupTest.SMTP, ServerSetupTest.IMAP })
-					.withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(
+            new ServerSetup[] { ServerSetupTest.SMTP, ServerSetupTest.IMAP })
+                    .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
 
-	@Test
-	public void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
-		final String to = "to@localhost";
-		final String subject = "subject";
-		final String body = "body";
-		GreenMailUtil.sendTextEmailTest(to, "from@localhost", subject, body);
-		MimeMessage[] emails = greenMail.getReceivedMessages();
-		assertEquals(1, emails.length);
-		assertEquals(subject, emails[0].getSubject());
-		assertEquals(body, GreenMailUtil.getBody(emails[0]));
+    @Test
+    public void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
+        final String to = "to@localhost";
+        final String subject = "subject";
+        final String body = "body";
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost", subject, body);
+        MimeMessage[] emails = greenMail.getReceivedMessages();
+        assertEquals(1, emails.length);
+        assertEquals(subject, emails[0].getSubject());
+        assertEquals(body, GreenMailUtil.getBody(emails[0]));
 
-		greenMail.waitForIncomingEmail(5000, 1);
+        greenMail.waitForIncomingEmail(5000, 1);
 
-		try (Retriever retriever = new Retriever(greenMail.getImap())) {
-			Message[] messages = retriever.getMessages(to);
-			assertEquals(1, messages.length);
-			assertEquals(subject, messages[0].getSubject());
-			assertEquals(body, messages[0].getContent());
-		}
-	}
+        try (Retriever retriever = new Retriever(greenMail.getImap())) {
+            Message[] messages = retriever.getMessages(to);
+            assertEquals(1, messages.length);
+            assertEquals(subject, messages[0].getSubject());
+            assertEquals(body, messages[0].getContent());
+        }
+    }
 
-	@Test
-	public void testReceiveWithAuthDisabled() {
-		final String to = "to@localhost";
+    @Test
+    public void testReceiveWithAuthDisabled() {
+        final String to = "to@localhost";
 
-		greenMail.waitForIncomingEmail(500, 1);
+        greenMail.waitForIncomingEmail(500, 1);
 
-		try (Retriever retriever = new Retriever(greenMail.getImap())) {
-			Message[] messages = retriever.getMessages(to);
-			assertEquals(0, messages.length);
-		}
-	}
+        try (Retriever retriever = new Retriever(greenMail.getImap())) {
+            Message[] messages = retriever.getMessages(to);
+            assertEquals(0, messages.length);
+        }
+    }
 
-	@Test
-	public void testReceiveWithAuthDisabledAndProvisionedUser() {
-		final String to = "to@localhost";
-		greenMail.setUser(to, "to", "secret");
+    @Test
+    public void testReceiveWithAuthDisabledAndProvisionedUser() {
+        final String to = "to@localhost";
+        greenMail.setUser(to, "to", "secret");
 
-		greenMail.waitForIncomingEmail(500, 1);
+        greenMail.waitForIncomingEmail(500, 1);
 
-		try (Retriever retriever = new Retriever(greenMail.getImap())) {
-			Message[] messages = retriever.getMessages(to);
-			assertEquals(0, messages.length);
-		}
-	}
+        try (Retriever retriever = new Retriever(greenMail.getImap())) {
+            Message[] messages = retriever.getMessages(to);
+            assertEquals(0, messages.length);
+        }
+    }
 
-	@Test
-	public void testPop3ConnectNoAuth() throws MessagingException, UserException, FolderException {
-		UserManager userManager = greenMail.getManagers().getUserManager();
-		Pop3State status = new Pop3State(userManager);
-		userManager.setAuthRequired(false);
+    @Test
+    public void testPop3ConnectNoAuth() throws MessagingException, UserException, FolderException {
+        UserManager userManager = greenMail.getManagers().getUserManager();
+        Pop3State status = new Pop3State(userManager);
+        userManager.setAuthRequired(false);
 
-		UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
-		status.setUser(user);
-		status.authenticate("pass");
-	}
+        UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
+        status.setUser(user);
+        status.authenticate("pass");
+    }
 
-	@Test(expected = UserException.class)
-	public void testPop3ConnectAuth() throws MessagingException, UserException, FolderException {
-		UserManager userManager = greenMail.getManagers().getUserManager();
-		Pop3State status = new Pop3State(userManager);
-		userManager.setAuthRequired(true);
+    @Test(expected = UserException.class)
+    public void testPop3ConnectAuth() throws MessagingException, UserException, FolderException {
+        UserManager userManager = greenMail.getManagers().getUserManager();
+        Pop3State status = new Pop3State(userManager);
+        userManager.setAuthRequired(true);
 
-		UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
-		status.setUser(user);
-		status.authenticate("pass");
-	}
+        UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
+        status.setUser(user);
+        status.authenticate("pass");
+    }
 
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
@@ -1,17 +1,16 @@
 package com.icegreen.greenmail.user;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.icegreen.greenmail.imap.ImapHostManager;
 import com.icegreen.greenmail.imap.ImapHostManagerImpl;
-import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.pop3.Pop3Server;
 import com.icegreen.greenmail.store.InMemoryStore;
-import com.icegreen.greenmail.store.MailFolder;
+import com.icegreen.greenmail.test.Pop3ServerTest;
+import com.sun.mail.pop3.POP3Store;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+
 
 public class UserManagerTest {
     @Test
@@ -68,8 +67,8 @@ public class UserManagerTest {
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(false);
 
-        assertTrue(userManager.listUser().isEmpty());
         assertTrue(userManager.test("foo@localhost", null));
+        assertEquals(1, userManager.listUser().size());
     }
 
     @Test
@@ -89,8 +88,8 @@ public class UserManagerTest {
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(true);
 
-        assertTrue(userManager.listUser().isEmpty());
         assertFalse(userManager.test("foo@localhost", null));
+        assertTrue(userManager.listUser().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
When `-Dgreenmail.auth.disabled` is set the password is ignored on POP (#260), it was already working as expected for IMAP.