### PR TITLE
String.contains is case sensitive so both participants needs to be lo…

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -241,7 +241,7 @@ public class GreenMail extends ConfiguredGreenMail {
         try {
             for (StoredMessage msg : msgs) {
                 String tos = GreenMailUtil.getAddressList(msg.getMimeMessage().getAllRecipients());
-                if (tos.toLowerCase().contains(domain)) {
+                if (tos.toLowerCase().contains(domain.toLowerCase())) {
                     ret.add(msg.getMimeMessage());
                 }
             }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/GreenMailTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/GreenMailTest.java
@@ -4,6 +4,8 @@ import com.icegreen.greenmail.junit.GreenMailRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import javax.mail.internet.MimeMessage;
+
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -28,6 +30,24 @@ public class GreenMailTest {
         assertThat(finish - start, is(lessThan(timePasswdMax)));
         final long timePassedMin = (long) (timeout * 0.9f);
         assertThat(finish - start, is(greaterThan(timePassedMin)));
+    }
+
+    @Test
+    public void getReceivedMessagesForDomainLowerCaseRecipientAddress() {
+        final String to = "to@localhost.com";
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", "subject", "body");
+
+        final MimeMessage[] receivedMessagesForDomain = greenMail.getReceivedMessagesForDomain(to);
+        assertThat(receivedMessagesForDomain.length, is(1));
+    }
+
+    @Test
+    public void getReceivedMessagesForDomainWithUpperCaseRecipientAddress() {
+        final String to = "someReceiver@localhost.com";
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost.com", "subject", "body");
+
+        final MimeMessage[] receivedMessagesForDomain = greenMail.getReceivedMessagesForDomain(to);
+        assertThat(receivedMessagesForDomain.length, is(1));
     }
 }
 


### PR DESCRIPTION
…wercase

String.contains is case sensitive and so both participants needs to be lowercased or not, otherwise if the domain has a uppercase value the result of `tos.toLowerCase().contains(domain)` will be false in every case.

See the `getReceivedMessagesForDomainWithUpperCaseRecipientAddress` test if you remove `domain.toLowerCase()` the test will fail.