### PR TITLE
Fix *.iml in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ nb-configuration.xml
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
 
-/*.iml
+*.iml
 
 ## Directory-based project format:
 .idea/


### PR DESCRIPTION
WIth /*.iml only the files on the first directory is found and not the others