### PR TITLE
feat: add the ability to instantiate GreenMail per-class in addition to per-method

### DIFF
--- a/greenmail-junit5/src/test/java/com/icegreen/greenmail/junit5/AlternateLifecyclesTests.java
+++ b/greenmail-junit5/src/test/java/com/icegreen/greenmail/junit5/AlternateLifecyclesTests.java
@@ -1,0 +1,77 @@
+package com.icegreen.greenmail.junit5;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("GreenMail with alternate lifecycles tests")
+class AlternateLifecyclesTests {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Per-Method lifecycle")
+    class PerMethodLifecycle {
+        @RegisterExtension
+        GreenMailExtension greenMail = new GreenMailExtension()
+            .withConfiguration(GreenMailConfiguration.aConfig()
+                .withUser("to@localhost.com", "login-id", "password"));
+
+        @Test
+        @DisplayName("Send test 1")
+        void testSend1() {
+            GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com", "some subject", "some body");
+            assertEquals(1, greenMail.getReceivedMessages().length);
+        }
+
+        @Test
+        @DisplayName("Send test 2")
+        void testSend2() {
+            GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com", "some subject", "some body");
+            assertEquals(1, greenMail.getReceivedMessages().length);
+        }
+
+        @AfterAll
+        public void afterAll() {
+            assertEquals(0, greenMail.getReceivedMessages().length);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Per-Class lifecycle")
+    class PerClassLifecycle {
+        @RegisterExtension
+        GreenMailExtension greenMail = new GreenMailExtension()
+            .withPerMethodLifecycle(false)
+            .withConfiguration(GreenMailConfiguration.aConfig()
+                .withUser("to@localhost.com", "login-id", "password"));
+
+        @Test
+        @DisplayName("Send test 1")
+        void testSend1() {
+            GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com", "some subject", "some body");
+        }
+
+        @Test
+        @DisplayName("Send test 2")
+        void testSend2() {
+            GreenMailUtil.sendTextEmailTest("to@localhost.com", "from@localhost.com", "some subject", "some body");
+        }
+
+        @AfterAll
+        public void afterAll() {
+            assertEquals(2, greenMail.getReceivedMessages().length);
+        }
+    }
+}


### PR DESCRIPTION
I had a use case where I needed GreenMail to be instantiated once per test class instead of once per test method. This behaviour was added to the JUnit5 `GreenMailExtension`. Of course, this change is made backwards compatible so it doesn't affect existing code. The corresponding test class `com.icegreen.greenmail.junit5.AlternateLifecyclesTests` shows how the lifecycle can be switched, essentially:

``` java
@RegisterExtension
GreenMailExtension greenMail = new GreenMailExtension()
    .withPerMethodLifecycle(false)
    .withConfiguration(...);
```

The extension works very well, please consider publishing the JUnit5 module to Maven Central.