### PR TITLE
Don't include one extra space after 334 response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/AuthCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/AuthCommand.java
@@ -96,9 +96,9 @@ public class AuthCommand
             conn.send(SMTP_SYNTAX_ERROR + " : Unsupported auth mechanism " + authMechanismValue +
                     " with unexpected values. Line is: <" + commandLine + ">");
         } else {
-            conn.send(SMTP_SERVER_CONTINUATION + " VXNlciBOYW1lAA=="); // "User Name"
+            conn.send(SMTP_SERVER_CONTINUATION + "VXNlciBOYW1lAA=="); // "User Name"
             String username = conn.receiveLine();
-            conn.send(SMTP_SERVER_CONTINUATION + " UGFzc3dvcmQA"); // Password
+            conn.send(SMTP_SERVER_CONTINUATION + "UGFzc3dvcmQA"); // Password
             String pwd = conn.receiveLine();
 
             if (manager.getUserManager().test(EncodingUtil.decodeBase64(username), EncodingUtil.decodeBase64(pwd))) {


### PR DESCRIPTION
The SMTP_SERVER_CONTINUATION constant already contains a space at the end and there is even a comment warning about that next to its definition.

It trips some clients up (Vert.x Mail client in my case) and is not according to spec which says `"334" SP [base64] CRLF` (looking at https://tools.ietf.org/html/rfc4954#ref-SASL).