### PR TITLE
IMAP IDLE support (RFC2177)

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapConstants.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapConstants.java
@@ -16,7 +16,7 @@ public interface ImapConstants {
 
     String SP = " ";
     String VERSION = "IMAP4rev1";
-    String CAPABILITIES = "LITERAL+" + SP + "SORT" + SP + "UIDPLUS";
+    String CAPABILITIES = "LITERAL+" + SP + "SORT" + SP + "UIDPLUS" + SP + "IDLE";
 
     String USER_NAMESPACE = "#mail";
 

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/IdleCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/IdleCommand.java
@@ -1,0 +1,84 @@
+package com.icegreen.greenmail.imap.commands;
+
+import java.net.SocketTimeoutException;
+
+import javax.mail.Flags;
+
+import com.icegreen.greenmail.imap.AuthorizationException;
+import com.icegreen.greenmail.imap.ImapRequestLineReader;
+import com.icegreen.greenmail.imap.ImapResponse;
+import com.icegreen.greenmail.imap.ImapSession;
+import com.icegreen.greenmail.imap.ImapSessionFolder;
+import com.icegreen.greenmail.imap.ProtocolException;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.store.FolderListener;
+
+class IdleCommand extends SelectedStateCommand {
+    public static final String NAME = "IDLE";
+    public static final String ARGS = null;
+
+    IdleCommand() {
+        super(NAME, ARGS);
+    }
+
+    @Override
+    protected void doProcess(ImapRequestLineReader request, ImapResponse response, ImapSession session)
+            throws ProtocolException, FolderException, AuthorizationException {
+        parser.endLine(request);
+        request.consume(); // TODO should be in eol()
+        session.unsolicitedResponses(response);
+        request.commandContinuationRequest();
+        ImapSessionFolder folder = session.getSelected();
+        IdleFolderListener listener = new IdleFolderListener(response);
+        try {
+            folder.addListener(listener);
+            waitForClientDone(request);
+            session.unsolicitedResponses(response);
+            response.commandComplete(this);
+        } finally {
+            folder.removeListener(listener);
+        }
+    }
+
+    private void waitForClientDone(ImapRequestLineReader request) throws ProtocolException {
+        while (true) {
+            try {
+                request.nextChar();
+                break;
+            } catch (ProtocolException e) {
+                if (e.getCause() instanceof SocketTimeoutException) {
+                    // ignore
+                } else {
+                    throw e;
+                }
+            }
+        }
+        // TODO validate 'DONE'
+    }
+
+    private static class IdleFolderListener implements FolderListener {
+        private ImapResponse response;
+
+        private IdleFolderListener(ImapResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public void mailboxDeleted() {
+        }
+
+        @Override
+        public void flagsUpdated(int msn, Flags flags, Long uid) {
+        }
+
+        @Override
+        public void expunged(int msn) {
+            response.expungeResponse(msn);
+        }
+
+        @Override
+        public void added(int msn) {
+            response.existsResponse(msn);
+        }
+    }
+}

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/ImapCommandFactory.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/ImapCommandFactory.java
@@ -72,6 +72,9 @@ public class ImapCommandFactory {
         imapCommands.put(SetQuotaCommand.NAME, SetQuotaCommand.class);
         imapCommands.put(QuotaCommand.NAME, QuotaCommand.class);
         imapCommands.put(QuotaRootCommand.NAME, QuotaRootCommand.class);
+
+        // RFC2177: IDLE
+        imapCommands.put(IdleCommand.NAME, IdleCommand.class);
     }
 
     public ImapCommand getCommand(String commandName) {


### PR DESCRIPTION
implements naive IDLE support:
* blocks thread after sending continuation request
* sends unsolicited responses for new and expunged messages

#275

Happy about feedback!