### PR TITLE
fix: skip intermediate conversion of email to string (fixes #429)

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/RetrCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/RetrCommand.java
@@ -14,7 +14,9 @@ import com.icegreen.greenmail.store.StoredMessage;
 import com.icegreen.greenmail.util.GreenMailUtil;
 
 import javax.mail.Flags;
-import java.io.StringReader;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 
 
@@ -42,9 +44,9 @@ public class RetrCommand
             }
 
             StoredMessage msg = msgList.get(0);
-            String email = GreenMailUtil.getWholeMessage(msg.getMimeMessage());
+            ByteArrayInputStream bis = new ByteArrayInputStream(GreenMailUtil.getWholeMessageAsBytes(msg.getMimeMessage()));
             conn.println("+OK");
-            conn.print(new StringReader(email));
+            conn.print(new InputStreamReader(bis));
             conn.println();
             conn.println(".");
             msg.setFlag(Flags.Flag.SEEN, true);

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/TopCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/TopCommand.java
@@ -14,7 +14,9 @@ import com.icegreen.greenmail.store.StoredMessage;
 import com.icegreen.greenmail.util.GreenMailUtil;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.List;
 
@@ -48,8 +50,8 @@ public class TopCommand
 
             int numLines = Integer.parseInt(cmdLine[2]);
 
-            try (BufferedReader in = new BufferedReader(
-                    new StringReader(GreenMailUtil.getWholeMessage(msg.getMimeMessage())))) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(
+                new ByteArrayInputStream(GreenMailUtil.getWholeMessageAsBytes(msg.getMimeMessage()))))) {
                 conn.println("+OK");
 
                 copyHeaders(in, conn);

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailUtil.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMailUtil.java
@@ -144,6 +144,19 @@ public class GreenMailUtil {
         }
     }
 
+    /**
+     * @return Both header and body for an email (or a Part) as encoding-agnostic byte[]
+     */
+    public static byte[] getWholeMessageAsBytes(Part msg) {
+        try {
+            ByteArrayOutputStream bodyOut = new ByteArrayOutputStream();
+            msg.writeTo(bodyOut);
+            return bodyOut.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     public static byte[] getBodyAsBytes(Part msg) {
         return getBody(msg).getBytes(EncodingUtil.CHARSET_EIGHT_BIT_ENCODING);
     }


### PR DESCRIPTION
In the previous version, when a Mail was sent, its `byte[]` content was converted to a String using a specific encoding just to be converted again to a `char[]` array. This intermediate conversion to a String is now skipped.

I added a new method to GreenMailUtil because
- changing the existing method which is now no longer strictly necessary will be a breaking change in the API since it's public
- providing such a method in GreenMailUtil - a class that can be used by GreenMail users- might help them as well

The PR is for the current 1.6.x branch. With minimal effort, it can be integrated to master; just the imports change.

*On my machine*<sup>TM</sup> (Ubuntu), the tests run fine.