### PR TITLE
fix IMAP search keyword parsing

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
@@ -85,7 +85,7 @@ public class CommandParser {
             case '{':
                 return new String(consumeLiteralAsBytes(request), charset);
             default:
-                return consumeWord(request);
+                return consumeWordOnly(request, chr -> chr != ')');
         }
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchCommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchCommandParserTest.java
@@ -69,6 +69,16 @@ public class SearchCommandParserTest {
         assertThat(searchTerm).isEqualTo(expectedTerm);
     }
 
+    @Test
+    public void testNotKeyword() throws ProtocolException {
+        Flags flags = new Flags();
+        flags.add("ABC");
+		SearchTerm expectedTerm = new NotTerm(new FlagTerm(flags, true));
+        SearchTerm searchTerm = parse("NOT (KEYWORD ABC)");
+
+        assertThat(searchTerm).isEqualTo(expectedTerm);
+    }
+
     private SearchTerm parse(String line) throws ProtocolException {
         final byte[] bytes = (line.endsWith("\n") ? line : (line + '\n')).getBytes();
         ByteArrayInputStream ins = new ByteArrayInputStream(bytes);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/commands/ImapSearchTest.java
@@ -92,6 +92,12 @@ public class ImapSearchTest {
             assertThat(imapMessages[1].getFlags().contains(fooFlags)).isFalse();
             assertThat(imapMessages[2].getFlags().contains(fooFlags)).isFalse();
 
+            imapMessages = imapFolder.search(new NotTerm(new FlagTerm(fooFlags, true)));
+            assertThat(imapMessages.length).isEqualTo(5);
+            assertThat(imapMessages[0].getFlags().contains(fooFlags)).isFalse();
+            assertThat(imapMessages[1].getFlags().contains(fooFlags)).isFalse();
+            assertThat(imapMessages[2].getFlags().contains(fooFlags)).isFalse();
+
             // Search header ids
             String id = m0.getHeader("Message-ID")[0];
             imapMessages = imapFolder.search(new HeaderTerm("Message-ID", id));


### PR DESCRIPTION
not the best fix. the spec says flag is an atom. but the same code path is used to parse e.g. UID 1:*. so we would maybe need to provide a way for search keys to specify the type of arguments.