### PR TITLE
Implement RFC5233 subaddress handling. Fixes #337

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
@@ -23,6 +23,7 @@ public abstract class ConfiguredGreenMail implements GreenMailOperations {
                 setUser(user.getEmail(), user.getLogin(), user.getPassword());
             }
             getUserManager().setAuthRequired(!config.isAuthenticationDisabled());
+            getUserManager().setSieveIgnoreDetail(config.isSieveIgnoreDetailEnabled());
         }
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class GreenMailConfiguration {
     private final List<UserBean> usersToCreate = new ArrayList<>();
     private boolean disableAuthenticationCheck = false;
+    private boolean sieveIgnoreDetail = false;
 
     /**
      * The given {@link com.icegreen.greenmail.user.GreenMailUser} will be created when servers will start.
@@ -67,5 +68,24 @@ public class GreenMailConfiguration {
      */
     public boolean isAuthenticationDisabled() {
         return disableAuthenticationCheck;
+    }
+
+    /**
+     * Enables Sieve detail handling, also known as RFC 5233 subaddress extension.
+     *
+     * @return Modified configuration.
+     */
+    public GreenMailConfiguration withSieveIgnoreDetail() {
+        sieveIgnoreDetail = true;
+        return this;
+    }
+
+    /**
+     * @return true, if Sieve detail handling is enabled.
+     *
+     * @see GreenMailConfiguration#withSieveIgnoreDetail() ()
+     */
+    public boolean isSieveIgnoreDetailEnabled() {
+        return sieveIgnoreDetail;
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
@@ -38,6 +38,8 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
      */
     public static final String GREENMAIL_AUTH_DISABLED = "greenmail.auth.disabled";
 
+    public static final String GREENMAIL_SIEVE_IGNORE_DETAIL = "greenmail.sieve.ignore.detail";
+
     /**
      * Configures how user login should be extracted from user of pattern local-part:password@domain .
      */
@@ -72,6 +74,12 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
         if (null != disabledAuthentication) {
             configuration.withDisabledAuthentication();
         }
+
+        String sieveIgnoreDetail = properties.getProperty(GREENMAIL_SIEVE_IGNORE_DETAIL, "false");
+        if (null != sieveIgnoreDetail) {
+            configuration.withSieveIgnoreDetail();
+        }
+
         return configuration;
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/SieveDetailHandlingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/SieveDetailHandlingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Shock Media B.V. - All Rights Reserved. Unauthorized copying
+ * and/or distribution of this file, via any medium, is strictly prohibited.
+ *
+ * Proprietary and confidential
+ */
+
+package com.icegreen.greenmail;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Test that, when Sieve detail handling is enabled, mail gets delivered to the
+ * correct user.
+ */
+public class SieveDetailHandlingTest {
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP)
+        .withConfiguration(new GreenMailConfiguration().withSieveIgnoreDetail());
+
+    @Test
+    public void testPlusSubaddressHandling() {
+        GreenMailUtil.sendTextEmailTest("foo+baz@bar.com", "here@localhost", "sub1", "msg1");
+
+        assertThat(greenMail.getUserManager().listUser()).hasSize(1);
+        assertThat(greenMail.getUserManager().getUserByEmail("foo@bar.com")).isNotNull();
+        assertThat(greenMail.getUserManager().getUserByEmail("foo+baz@bar.com")).isNull();
+    }
+
+    @Test
+    public void testMinusSubaddressHandling() {
+        GreenMailUtil.sendTextEmailTest("foo--baz@bar.com", "here@localhost", "sub1", "msg1");
+
+        assertThat(greenMail.getUserManager().listUser()).hasSize(1);
+        assertThat(greenMail.getUserManager().getUserByEmail("baz@bar.com")).isNotNull();
+        assertThat(greenMail.getUserManager().getUserByEmail("foo--baz@bar.com")).isNull();
+    }
+
+    @Test
+    public void testSubaddressHandlingDisabled() {
+        greenMail.getUserManager().setSieveIgnoreDetail(false);
+        GreenMailUtil.sendTextEmailTest("foo+baz@bar.com", "here@localhost", "sub2", "msg2");
+
+        assertThat(greenMail.getUserManager().listUser()).hasSize(1);
+        assertThat(greenMail.getUserManager().getUserByEmail("foo@bar.com")).isNull();
+        assertThat(greenMail.getUserManager().getUserByEmail("foo+baz@bar.com")).isNotNull();
+
+    }
+
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
@@ -54,6 +54,15 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
         assertThat(config.isAuthenticationDisabled()).isTrue();
     }
 
+    @Test
+    public void testBuildWithSieveIgnoreDetailEnabledSetting() {
+        Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_SIEVE_IGNORE_DETAIL, "");
+        GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
+
+        assertThat(config).isNotNull();
+        assertThat(config.isSieveIgnoreDetailEnabled()).isTrue();
+    }
+
     private Properties createPropertiesFor(String key, String value) {
         Properties props = new Properties();
         props.setProperty(key, value);


### PR DESCRIPTION
Adds support for subaddressing. Can be enabled in the standalone version by adding `-Dgreenmail.sieve.ignore.detail` as suggested in #337 and in unit tests by calling `GreenMailConfiguration#withSieveIgnoreDetail`. 