### PR TITLE
JUnit 5 migration for greenmail

### DIFF
--- a/greenmail-core/pom.xml
+++ b/greenmail-core/pom.xml
@@ -99,6 +99,11 @@
       <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/AuthenticationDisabledTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/AuthenticationDisabledTest.java
@@ -1,7 +1,14 @@
 package com.icegreen.greenmail;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.pop3.Pop3State;
 import com.icegreen.greenmail.store.FolderException;
 import com.icegreen.greenmail.user.UserException;
@@ -14,21 +21,15 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AuthenticationDisabledTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(
             new ServerSetup[] { ServerSetupTest.SMTP, ServerSetupTest.IMAP })
                     .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
 
     @Test
-    public void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
+    void testSendMailAndReceiveWithAuthDisabled() throws MessagingException, IOException {
         final String to = "to@localhost";
         final String subject = "subject";
         final String body = "body";
@@ -49,7 +50,7 @@ public class AuthenticationDisabledTest {
     }
 
     @Test
-    public void testReceiveWithAuthDisabled() {
+    void testReceiveWithAuthDisabled() {
         final String to = "to@localhost";
 
         greenMail.waitForIncomingEmail(500, 1);
@@ -61,7 +62,7 @@ public class AuthenticationDisabledTest {
     }
 
     @Test
-    public void testReceiveWithAuthDisabledAndProvisionedUser() {
+    void testReceiveWithAuthDisabledAndProvisionedUser() {
         final String to = "to@localhost";
         greenMail.setUser(to, to, "secret");
 
@@ -74,7 +75,7 @@ public class AuthenticationDisabledTest {
     }
 
     @Test
-    public void testPop3ConnectNoAuth() throws UserException, FolderException {
+    void testPop3ConnectNoAuth() throws UserException, FolderException {
         UserManager userManager = greenMail.getUserManager();
         Pop3State status = new Pop3State(userManager);
         userManager.setAuthRequired(false);
@@ -84,15 +85,15 @@ public class AuthenticationDisabledTest {
         status.authenticate("pass");
     }
 
-    @Test(expected = UserException.class)
-    public void testPop3ConnectAuth() throws UserException, FolderException {
+    @Test
+    void testPop3ConnectAuth() {
         UserManager userManager = greenMail.getUserManager();
         Pop3State status = new Pop3State(userManager);
         userManager.setAuthRequired(true);
 
         UserImpl user = new UserImpl("email@example.com", "user", "pwd", null);
         status.setUser(user);
-        status.authenticate("pass");
+        assertThatThrownBy(() -> status.authenticate("pass")).isInstanceOf(UserException.class);
     }
 
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/CatchAllTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/CatchAllTest.java
@@ -1,24 +1,25 @@
 package com.icegreen.greenmail;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Wael Chatila
  * @version $Id: $
  * @since May 27th, 2009
  */
-public class CatchAllTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+class CatchAllTest {
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
     @Test
-    public void testSmtpServerBasic() {
+    void testSmtpServerBasic() {
         GreenMailUtil.sendTextEmailTest("to11@domain1.com", "from@localhost", "subject", "body");
         GreenMailUtil.sendTextEmailTest("to12@domain1.com", "from@localhost", "subject", "body");
         GreenMailUtil.sendTextEmailTest("to21@domain2.com", "from@localhost", "subject", "body");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/ConcurrentCloseIT.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/ConcurrentCloseIT.java
@@ -4,19 +4,19 @@ import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConcurrentCloseIT {
+class ConcurrentCloseIT {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private int limitIterations;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         final String envValue = System.getenv("ConcurrentCloseIT_ITERATIONS");
         if (null == envValue) {
             limitIterations = 2500;
@@ -25,7 +25,7 @@ public class ConcurrentCloseIT {
     }
 
     @Test
-    public void concurrentCloseTest() throws Exception {
+    void concurrentCloseTest() throws Exception {
         final long startTime = System.currentTimeMillis();
         for (int i = 0; i < limitIterations; i++) {
             testThis();
@@ -60,6 +60,7 @@ public class ConcurrentCloseIT {
     private static class SenderThread extends Thread {
         RuntimeException exc;
 
+        @Override
         public void run() {
             try {
                 GreenMailUtil.sendTextEmail("test@localhost", "from@localhost", "abc", "def",

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/DummySSLServerSocketFactoryTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/DummySSLServerSocketFactoryTest.java
@@ -13,10 +13,10 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -30,39 +30,39 @@ import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DummySSLServerSocketFactoryTest {
-    @BeforeClass
-    public static void setUp() {
+class DummySSLServerSocketFactoryTest {
+    @BeforeAll
+    static void setUp() {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @AfterAll
+    static void tearDown() {
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
     }
 
-    @After
-    public void cleanup() {
+    @AfterEach
+    void cleanup() {
         System.clearProperty(DummySSLServerSocketFactory.GREENMAIL_KEYSTORE_FILE_PROPERTY);
         System.clearProperty(DummySSLServerSocketFactory.GREENMAIL_KEYSTORE_PASSWORD_PROPERTY);
         System.clearProperty(DummySSLServerSocketFactory.GREENMAIL_KEY_PASSWORD_PROPERTY);
     }
 
     @Test
-    public void testLoadDefaultKeyStore() throws KeyStoreException {
+    void testLoadDefaultKeyStore() throws KeyStoreException {
         DummySSLServerSocketFactory factory = new DummySSLServerSocketFactory();
         KeyStore ks = factory.getKeyStore();
         assertThat(ks.containsAlias("greenmail")).isTrue();
     }
 
     @Test
-    public void testLoadKeyStoreViaSystemPropertyWithDefaultKeyPwd()
+    void testLoadKeyStoreViaSystemPropertyWithDefaultKeyPwd()
         throws GeneralSecurityException, IOException, OperatorCreationException {
         testLoadKeyStoreViaSystemProperty("store password", null);
     }
 
     @Test
-    public void testLoadKeyStoreViaSystemPropertyWithProvidedKeyPwd()
+    void testLoadKeyStoreViaSystemPropertyWithProvidedKeyPwd()
         throws GeneralSecurityException, IOException, OperatorCreationException {
         testLoadKeyStoreViaSystemProperty("store password", "key password");
     }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/MultiRequestTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/MultiRequestTest.java
@@ -8,13 +8,13 @@ package com.icegreen.greenmail;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.server.AbstractServer;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.*;
  * Test multiple senders and receivers using all available protocols
  */
 public class MultiRequestTest {
-    protected final static Logger log = LoggerFactory.getLogger(MultiRequestTest.class);
+    protected static final Logger log = LoggerFactory.getLogger(MultiRequestTest.class);
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.ALL);
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.ALL);
 
     //~ INNER CLASSES -----------------------------------------------
     private static class SenderThread extends Thread {
@@ -41,6 +41,7 @@ public class MultiRequestTest {
             this.count = count;
         }
 
+        @Override
         public void run() {
             for (int i = 0; i < count; i++) {
                 GreenMailUtil.sendTextEmailTest(to, "from@localhost", "subject", "body");
@@ -62,6 +63,7 @@ public class MultiRequestTest {
             this.expectedCount = expectedCount;
         }
 
+        @Override
         public void run() {
             // Try several times, as message might not have been sent yet
             // If message is not sent after timeout period we abort
@@ -89,7 +91,7 @@ public class MultiRequestTest {
     //~ END INNER CLASSES -----------------------------------------------
 
     @Test
-    public void test20Senders() {
+    void test20Senders() {
         final int num = 20;
         addUsers(num);
         startSenderThreads(num);
@@ -100,7 +102,7 @@ public class MultiRequestTest {
     }
 
     @Test
-    public void test20Senders20x4Retrievers() throws InterruptedException {
+    void test20Senders20x4Retrievers() throws InterruptedException {
         final int num = 20;
         addUsers(num);
         startSenderThreads(num);
@@ -123,7 +125,7 @@ public class MultiRequestTest {
     }
 
     @Test
-    public void test20Senders20x4RetrieversAtTheSameTime() throws InterruptedException {
+    void test20Senders20x4RetrieversAtTheSameTime() throws InterruptedException {
         final int num = 20;
         addUsers(num);
         startSenderThreads(num);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/SendReceiveWithDifferentEncodingsTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/SendReceiveWithDifferentEncodingsTest.java
@@ -1,14 +1,14 @@
 package com.icegreen.greenmail;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -17,18 +17,18 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SendReceiveWithDifferentEncodingsTest {
+class SendReceiveWithDifferentEncodingsTest {
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3);
 
     @Test
-    public void testSendUtf8EncodedMessage() throws MessagingException, IOException {
+    void testSendUtf8EncodedMessage() throws MessagingException, IOException {
         testSendingAndRetrievingMaintainsEncoding(StandardCharsets.UTF_8);
     }
 
     @Test
-    public void testSendIso8859EncodedMessage() throws MessagingException, IOException {
+    void testSendIso8859EncodedMessage() throws MessagingException, IOException {
         testSendingAndRetrievingMaintainsEncoding(StandardCharsets.ISO_8859_1);
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/SendReceiveWithInternationalAddressTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/SendReceiveWithInternationalAddressTest.java
@@ -1,10 +1,10 @@
 package com.icegreen.greenmail;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -20,7 +20,7 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SendReceiveWithInternationalAddressTest {
+class SendReceiveWithInternationalAddressTest {
 
     static final Properties properties;
 
@@ -30,11 +30,11 @@ public class SendReceiveWithInternationalAddressTest {
         properties.put("mail.mime.address.strict", Boolean.FALSE.toString());
     }
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testSend() throws MessagingException, IOException {
+    void testSend() throws MessagingException, IOException {
         Session session = GreenMailUtil.getSession(ServerSetupTest.SMTP, properties);
         MimeMessage mimeMessage = new MockInternationalizedMimeMessage(session);
         mimeMessage.setSubject("subject");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/ServerStartStopTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/ServerStartStopTest.java
@@ -3,7 +3,7 @@ package com.icegreen.greenmail;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -11,9 +11,9 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Test that checks if greenmail start, stop and reset works correctly
  */
-public class ServerStartStopTest {
+class ServerStartStopTest {
     @Test
-    public void testStartStop() {
+    void testStartStop() {
         GreenMail service = new GreenMail(ServerSetupTest.ALL);
         try {
             // Try to stop before start: Nothing happens
@@ -31,7 +31,7 @@ public class ServerStartStopTest {
     }
 
     @Test
-    public void testServerStartupTimeout() {
+    void testServerStartupTimeout() {
         // Create a few setups
         ServerSetup[] setups = new ServerSetup[ServerSetupTest.ALL.length];
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/SieveDetailHandlingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/SieveDetailHandlingTest.java
@@ -7,15 +7,15 @@
 
 package com.icegreen.greenmail;
 
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Test that, when Sieve detail handling is enabled, mail gets delivered to the
@@ -23,12 +23,12 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class SieveDetailHandlingTest {
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP)
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP)
         .withConfiguration(new GreenMailConfiguration().withSieveIgnoreDetail());
 
     @Test
-    public void testPlusSubaddressHandling() {
+    void testPlusSubaddressHandling() {
         GreenMailUtil.sendTextEmailTest("foo+baz@bar.com", "here@localhost", "sub1", "msg1");
 
         assertThat(greenMail.getUserManager().listUser()).hasSize(1);
@@ -37,7 +37,7 @@ public class SieveDetailHandlingTest {
     }
 
     @Test
-    public void testMinusSubaddressHandling() {
+    void testMinusSubaddressHandling() {
         GreenMailUtil.sendTextEmailTest("foo--baz@bar.com", "here@localhost", "sub1", "msg1");
 
         assertThat(greenMail.getUserManager().listUser()).hasSize(1);
@@ -46,7 +46,7 @@ public class SieveDetailHandlingTest {
     }
 
     @Test
-    public void testSubaddressHandlingDisabled() {
+    void testSubaddressHandlingDisabled() {
         greenMail.getUserManager().setSieveIgnoreDetail(false);
         GreenMailUtil.sendTextEmailTest("foo+baz@bar.com", "here@localhost", "sub2", "msg2");
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailConfigurationTest.java
@@ -2,16 +2,17 @@ package com.icegreen.greenmail.configuration;
 
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Test;
 
 import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBase.testUsersAccessibleConfig;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests if the configuration is applied correctly to GreenMail instances.
  */
-public class GreenMailConfigurationTest {
+class GreenMailConfigurationTest {
     @Test
-    public void testUsersAccessible() {
+    void testUsersAccessible() {
         GreenMail greenMail = new GreenMail(ServerSetupTest.IMAP).withConfiguration(
                 testUsersAccessibleConfig()
         );

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/GreenMailRuleConfigurationTest.java
@@ -1,23 +1,22 @@
 package com.icegreen.greenmail.configuration;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import static com.icegreen.greenmail.configuration.GreenMailConfigurationTestBase.testUsersAccessibleConfig;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.ServerSetupTest;
 
 /**
  * Tests that check if the GreenMailConfiguration is applied correctly to GreenMailRules
  */
-public class GreenMailRuleConfigurationTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP).withConfiguration(
-            testUsersAccessibleConfig()
-    );
+class GreenMailRuleConfigurationTest {
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.IMAP).withConfiguration(testUsersAccessibleConfig());
 
     @Test
-    public void testUsersAccessible() {
+    void testUsersAccessible() {
         GreenMailConfigurationTestBase.testUsersAccessible(greenMail);
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
@@ -1,14 +1,14 @@
 package com.icegreen.greenmail.configuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.*;
 
-public class PropertiesBasedGreenMailConfigurationBuilderTest {
+class PropertiesBasedGreenMailConfigurationBuilderTest {
     @Test
-    public void testBuildForSingleUser() {
+    void testBuildForSingleUser() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS,
                 "foo1:pwd1@bar.com");
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
@@ -19,7 +19,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuildForListOfUsers() {
+    void testBuildForListOfUsers() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS,
                 "foo1:pwd1@bar.com,foo2:pwd2,foo3:pwd3@bar3.com");
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
@@ -32,7 +32,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuildForListOfUsersWithEmailAsLogin() {
+    void testBuildForListOfUsersWithEmailAsLogin() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS,
                 "foo1:pwd1@bar.com,foo2:pwd2,foo3:pwd3@bar3.com");
         props.setProperty(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS_LOGIN,"email");
@@ -46,7 +46,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuildWithAuthenticationDisabledSetting() {
+    void testBuildWithAuthenticationDisabledSetting() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_AUTH_DISABLED, "");
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
 
@@ -55,7 +55,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuildWithSieveIgnoreDetailEnabledSetting() {
+    void testBuildWithSieveIgnoreDetailEnabledSetting() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_SIEVE_IGNORE_DETAIL, "");
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
 
@@ -64,7 +64,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuildWithPreloadDir() {
+    void testBuildWithPreloadDir() {
         final String preloadDir = "/preload";
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_PRELOAD_DIR, preloadDir);
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleDisableAuthenticationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleDisableAuthenticationTest.java
@@ -1,27 +1,27 @@
 package com.icegreen.greenmail.examples;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.icegreen.greenmail.configuration.GreenMailConfiguration;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.Message;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Youssuf ElKalay.
  * Example using GreenMailConfiguration to test authenticating against SMTP/IMAP/POP3 with no password required.
  */
-public class ExampleDisableAuthenticationTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP)
+class ExampleDisableAuthenticationTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP)
             .withConfiguration(GreenMailConfiguration.aConfig().withDisabledAuthentication());
 
     @Test
-    public void testNoAuthIMAP() {
+    void testNoAuthIMAP() {
         try (Retriever retriever = new Retriever(greenMail.getImap())) {
             Message[] messages = retriever.getMessages("foo@localhost");
             assertThat(messages).isEmpty();
@@ -29,7 +29,7 @@ public class ExampleDisableAuthenticationTest {
     }
 
     @Test
-    public void testExistingUserNotRecreated() {
+    void testExistingUserNotRecreated() {
         try (Retriever retriever = new Retriever(greenMail.getImap())) {
             Message[] messages = retriever.getMessages("foo@localhost");
             assertThat(messages).isEmpty();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleFindUserByAuthLoginTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleFindUserByAuthLoginTest.java
@@ -1,5 +1,11 @@
 package com.icegreen.greenmail.examples;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.icegreen.greenmail.smtp.auth.AuthenticationState;
 import com.icegreen.greenmail.smtp.auth.UsernameAuthentication;
 import com.icegreen.greenmail.store.FolderException;
@@ -15,11 +21,6 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.Message.RecipientType;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * By default, GreenMail delivers messages to the user based on the email address
@@ -28,11 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This example illustrates how you can use a custom message delivery handler to deliver
  * messages based on the login that was used to authenticate against the mail server.
  */
-public class ExampleFindUserByAuthLoginTest {
+class ExampleFindUserByAuthLoginTest {
     public GreenMail greenMail;
 
     @Test
-    public void testSend() throws MessagingException, UserException, FolderException {
+    void testSend() throws MessagingException, UserException, FolderException {
         final UserManager userManager = greenMail.getUserManager();
         // Create a new user
         userManager.createUser("from@localhost", "login", "pass");
@@ -66,14 +67,14 @@ public class ExampleFindUserByAuthLoginTest {
         assertThat(createdMessage.getMimeMessage().getFrom()[0]).hasToString("mary@example.com");
     }
 
-    @Before
-    public void setupMail() {
+    @BeforeEach
+    void setupMail() {
         greenMail = new GreenMail(ServerSetupTest.SMTP);
         greenMail.start();
     }
 
-    @After
-    public void tearDownMail() {
+    @AfterEach
+    void tearDownMail() {
         greenMail.stop();
     }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleJavaMailTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleJavaMailTest.java
@@ -1,26 +1,31 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.imap.IMAPStore;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.mail.*;
+import org.eclipse.angus.mail.imap.IMAPStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Example using plain JavaMail for sending / receiving mails via GreenMail server.
  */
-public class ExampleJavaMailTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class ExampleJavaMailTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testSendAndReceive() throws MessagingException {
+    void testSendAndReceive() throws MessagingException {
         Session smtpSession = greenMail.getSmtp().createSession();
 
         Message msg = new MimeMessage(smtpSession);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExamplePreloadMailFromFsTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExamplePreloadMailFromFsTest.java
@@ -1,8 +1,18 @@
 package com.icegreen.greenmail.examples;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.icegreen.greenmail.imap.ImapConstants;
 import com.icegreen.greenmail.imap.ImapHostManager;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.user.UserManager;
 import com.icegreen.greenmail.util.ServerSetupTest;
@@ -10,28 +20,19 @@ import jakarta.mail.Message;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Example for loading Emails from EML file.
  * <p>
  * For preloading an existing directory structure, check out {@link  com.icegreen.greenmail.util.PreLoadEmailsTest}
  */
-public class ExamplePreloadMailFromFsTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+class ExamplePreloadMailFromFsTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
     public static final String EML_FILE_NAME = ExamplePreloadMailFromFsTest.class.getSimpleName() + ".eml";
 
     @Test
-    public void testPreloadMailFromFs() throws Exception {
+    void testPreloadMailFromFs() throws Exception {
         final Session session = greenMail.getSmtp().createSession();
 
         // Create test data

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExamplePurgeAllEmailsTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExamplePurgeAllEmailsTest.java
@@ -1,28 +1,28 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.store.FolderException;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.Message;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by Youssuf ElKalay.
  * Example using GreenMail.purgeEmailFromAllMailboxes() to test removing emails from all configured mailboxes - either
  * POP3 or IMAP.
  */
-public class ExamplePurgeAllEmailsTest {
-    @Rule
-    public final GreenMailRule greenMailRule = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+class ExamplePurgeAllEmailsTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMailRule = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP);
 
     @Test
-    public void testRemoveAllMessagesInImapMailbox() throws FolderException {
+    void testRemoveAllMessagesInImapMailbox() throws FolderException {
         try (Retriever retriever = new Retriever(greenMailRule.getImap())) {
             greenMailRule.setUser("foo@localhost", "pwd");
             GreenMailUtil.sendTextEmail("foo@localhost", "bar@localhost",

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleReceiveNoRuleTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleReceiveNoRuleTest.java
@@ -4,15 +4,15 @@ import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.mail.internet.MimeMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExampleReceiveNoRuleTest {
+class ExampleReceiveNoRuleTest {
     @Test
-    public void testReceive() {
+    void testReceive() {
         //Start all email servers using non-default ports.
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
         try {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleReceiveTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleReceiveTest.java
@@ -1,22 +1,22 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.internet.MimeMessage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class ExampleReceiveTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class ExampleReceiveTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testReceive() {
+    void testReceive() {
         GreenMailUser user = greenMail.setUser("to@localhost", "login-id", "password");
         user.deliver(createMimeMessage()); // You can either create a more complex message...
         GreenMailUtil.sendTextEmailTest("to@localhost", "from@localhost",

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleRuleTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleRuleTest.java
@@ -1,24 +1,24 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ExampleRuleTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+class ExampleRuleTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testSomething() throws MessagingException, IOException {
+    void testSomething() throws MessagingException, IOException {
         GreenMailUtil.sendTextEmailTest("to@localhost", "from@localhost", "subject", "content");
         MimeMessage[] emails = greenMail.getReceivedMessages();
         assertThat(emails).hasSize(1);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendNoRuleAdvTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendNoRuleAdvTest.java
@@ -3,7 +3,7 @@ package com.icegreen.greenmail.examples;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -13,9 +13,9 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExampleSendNoRuleAdvTest {
+class ExampleSendNoRuleAdvTest {
     @Test
-    public void testSend() throws MessagingException, IOException {
+    void testSend() throws MessagingException, IOException {
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
         try {
             greenMail.start();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendNoRuleSimpleTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendNoRuleSimpleTest.java
@@ -1,18 +1,19 @@
 package com.icegreen.greenmail.examples;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.MessagingException;
-import org.junit.Test;
 
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class ExampleSendNoRuleSimpleTest {
+class ExampleSendNoRuleSimpleTest {
     @Test
-    public void testSend() throws MessagingException, IOException {
+    void testSend() throws MessagingException, IOException {
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP); //uses test ports by default
         try {
             greenMail.start();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendReceiveMessageWithInlineAttachmentTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendReceiveMessageWithInlineAttachmentTest.java
@@ -1,18 +1,27 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import jakarta.mail.*;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -20,17 +29,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author https://github.com/DavidWhitlock
  */
-public class ExampleSendReceiveMessageWithInlineAttachmentTest {
+class ExampleSendReceiveMessageWithInlineAttachmentTest {
 
     private final String emailAddress = "test@email.com";
     private final String imapUserName = "emailUser";
     private final String imapPassword = "emailPassword";
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void sendAndFetchMailMessageWithInlineAttachment() throws IOException, MessagingException {
+    void sendAndFetchMailMessageWithInlineAttachment() throws IOException, MessagingException {
         greenMail.setUser(emailAddress, imapUserName, imapPassword);
 
         sendMailMessageWithInlineAttachment();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleSendTest.java
@@ -1,44 +1,41 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.MessagingException;
-import org.junit.Rule;
-import org.junit.Test;
 
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-public class ExampleSendTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+class ExampleSendTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
     @Test
-    public void testSend() throws MessagingException, IOException {
+    void testSend() throws MessagingException, IOException {
         GreenMailUtil.sendTextEmailTest("to@localhost", "from@localhost",
             "some subject", "some body"); // --- Place your sending code here instead
         assertThat(greenMail.getReceivedMessages()[0].getContent()).isEqualTo("some body");
     }
 
     @Test
-    public void testSendWithAvailablePortDetection() throws MessagingException, IOException {
+    void testSendWithAvailablePortDetection() throws MessagingException, IOException {
         GreenMail greenMailWithDynamicPort = new GreenMail(ServerSetupTest.SMTP.dynamicPort()); // Port would collide with ExampleSendTest.greenMail
         greenMailWithDynamicPort.start();
         try { // Be nice and always close started instance
             GreenMailUtil.sendTextEmail(
                 "to@localhost", "from@localhost", "some subject", "Sent using available port detection",
                 greenMailWithDynamicPort.getSmtp().getServerSetup()); // Important: Pass dynamic port setup here
-            assertEquals("Sent using available port detection",
-                greenMailWithDynamicPort.getReceivedMessages()[0].getContent());
-            assertEquals("Unexpected default test port",
-                ServerSetupTest.SMTP.getPort(), greenMail.getSmtp().getPort());
-            assertNotEquals("Dynamic port must differ",
-                ServerSetupTest.SMTP.getPort(), greenMailWithDynamicPort.getSmtp().getPort());
+            assertEquals("Sent using available port detection", greenMailWithDynamicPort.getReceivedMessages()[0].getContent());
+            assertEquals(ServerSetupTest.SMTP.getPort(), greenMail.getSmtp().getPort(), "Unexpected default test port");
+            assertNotEquals(ServerSetupTest.SMTP.getPort(), greenMailWithDynamicPort.getSmtp().getPort(), "Dynamic port must differ");
         } finally {
             greenMailWithDynamicPort.stop();
         }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleUndeliverableTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/examples/ExampleUndeliverableTest.java
@@ -1,6 +1,11 @@
 package com.icegreen.greenmail.examples;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.user.MessageDeliveryHandler;
 import com.icegreen.greenmail.user.UserException;
@@ -10,17 +15,13 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.Message.RecipientType;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class ExampleUndeliverableTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+class ExampleUndeliverableTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
     @Test
-    public void testSend() throws MessagingException, UserException {
+    void testSend() throws MessagingException, UserException {
         final UserManager userManager = greenMail.getUserManager();
         userManager.createUser("from@localhost", "from@localhost", "from@localhost");
         MessageDeliveryHandler defaultMessageDeliveryHandler = userManager.getMessageDeliveryHandler();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSearchTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSearchTest.java
@@ -4,8 +4,17 @@
  */
 package com.icegreen.greenmail.imap;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.icegreen.greenmail.imap.commands.SearchKey;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.ServerSetupTest;
@@ -18,28 +27,34 @@ import jakarta.mail.Session;
 import jakarta.mail.Store;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.search.*;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import static junit.framework.TestCase.fail;
-import static org.assertj.core.api.Assertions.assertThat;
+import jakarta.mail.search.AndTerm;
+import jakarta.mail.search.BodyTerm;
+import jakarta.mail.search.ComparisonTerm;
+import jakarta.mail.search.DateTerm;
+import jakarta.mail.search.FlagTerm;
+import jakarta.mail.search.FromStringTerm;
+import jakarta.mail.search.FromTerm;
+import jakarta.mail.search.HeaderTerm;
+import jakarta.mail.search.NotTerm;
+import jakarta.mail.search.OrTerm;
+import jakarta.mail.search.ReceivedDateTerm;
+import jakarta.mail.search.RecipientStringTerm;
+import jakarta.mail.search.RecipientTerm;
+import jakarta.mail.search.SearchTerm;
+import jakarta.mail.search.SentDateTerm;
+import jakarta.mail.search.SubjectTerm;
 
 /**
  * @author Wael Chatila
  * @version $Id: $
  * @since Jan 28, 2006
  */
-public class ImapSearchTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.ALL);
+class ImapSearchTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.ALL);
 
     @Test
-    public void testSearch() throws Exception {
+    void testSearch() throws Exception {
         GreenMailUser user = greenMail.setUser("to1@localhost", "pwd");
         assertThat(greenMail.getImap()).isNotNull();
 
@@ -183,7 +198,7 @@ public class ImapSearchTest {
     }
 
     @Test
-    public void testSearchIssue319() throws Exception {
+    void testSearchIssue319() throws Exception {
         String from = "from@localhost";
         String to = from;
         String subject = "Greenmail";
@@ -270,7 +285,7 @@ public class ImapSearchTest {
 
     // Test an unsupported search term for exception. Should be ignored.
     @Test
-    public void testUnsupportedSearchWarnsButDoesNotThrowException() {
+    void testUnsupportedSearchWarnsButDoesNotThrowException() {
         try {
             SearchKey.valueOf("SENTDATE");
             fail("Expected IAE for unimplemented search");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapServerTest.java
@@ -15,6 +15,7 @@ import org.eclipse.angus.mail.imap.AppendUID;
 import org.eclipse.angus.mail.imap.IMAPFolder;
 import org.eclipse.angus.mail.imap.IMAPStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.icegreen.greenmail.junit5.GreenMailExtension;
@@ -757,7 +758,8 @@ class ImapServerTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(10000)
     void testIdle() throws MessagingException {
         greenMail.setUser("foo@localhost", "pwd");
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSortTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSortTest.java
@@ -1,33 +1,39 @@
 package com.icegreen.greenmail.imap;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.angus.mail.imap.IMAPFolder;
+import org.eclipse.angus.mail.imap.SortTerm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.imap.IMAPFolder;
-import org.eclipse.angus.mail.imap.SortTerm;
-import org.junit.Rule;
-import org.junit.Test;
-
-import jakarta.mail.*;
+import jakarta.mail.Address;
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.search.*;
-
-import static org.assertj.core.api.Assertions.*;
+import jakarta.mail.search.FlagTerm;
 
 /**
  * Created on 10/03/2016.
  *
  * @author Reda.Housni-Alaoui
  */
-public class ImapSortTest {
+class ImapSortTest {
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.ALL);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.ALL);
 
     @Test
-    public void testSort() throws Exception {
+    void testSort() throws Exception {
         GreenMailUser user = greenMail.setUser("to1@localhost", "pwd");
         assertThat(greenMail.getImap()).isNotNull();
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSubjectLineTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapSubjectLineTest.java
@@ -4,13 +4,15 @@
  */
 package com.icegreen.greenmail.imap;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.Address;
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
@@ -20,15 +22,13 @@ import jakarta.mail.Store;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 
-import static org.assertj.core.api.Assertions.assertThat;
+class ImapSubjectLineTest {
 
-public class ImapSubjectLineTest {
-
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.IMAP);
 
     @Test
-    public void testLongSubjectLine() throws Exception {
+    void testLongSubjectLine() throws Exception {
         String longSubjectLine = "test subject line jumped over the lazy lorem ipsum looking dog, after which the subject line became long enough to trigger some folding.               it was a dark and stormy night, after all.  pretty sure the initial trigger " +
                 "for this test case did not have a subject line longer than 1000 chars, but there you go.  not sure what exactly what wouldve caused the folding, but maybe it happened on a somewhat shorter subject line.  whatever.";
 
@@ -36,7 +36,7 @@ public class ImapSubjectLineTest {
     }
 
     @Test
-    public void testSubjectWithEmbeddedSpaces() throws Exception {
+    void testSubjectWithEmbeddedSpaces() throws Exception {
         String subjectWithEmbeddedSpaces = "test subject line jumped over the lazy lorem ipsum looking dog, after which the subject line became long enough to trigger some folding.               it was a dark and stormy night, after all.  pretty sure the initial trigger " +
                 "for this test case did not have a subject line longer than 1000 chars, but there you go.  not sure what exactly what would've caused the folding, but maybe it happened on a somewhat shorter subject line.  whatever.";
 
@@ -44,28 +44,28 @@ public class ImapSubjectLineTest {
     }
 
     @Test
-    public void testSubjectWithSingleQuote() throws Exception {
+    void testSubjectWithSingleQuote() throws Exception {
         String subjectWithSingleQuote = "This is'nt a bad subject";
 
         testSubject(subjectWithSingleQuote);
     }
 
     @Test
-    public void testSubjectWithDoubleQuote() throws Exception {
+    void testSubjectWithDoubleQuote() throws Exception {
         String subjectWithDoubleQuote = "This is\"nt a bad subject";
 
         testSubject(subjectWithDoubleQuote);
     }
 
     @Test
-    public void testSubjectWithTabCharacter() throws Exception {
+    void testSubjectWithTabCharacter() throws Exception {
         String subjectWithTabCharacter = "The tab\t was there.";
 
         testSubject(subjectWithTabCharacter);
     }
 
     @Test
-    public void testSubjectWithBackslashCharacter() throws Exception {
+    void testSubjectWithBackslashCharacter() throws Exception {
         String subjectWithBackslashCharacter = "With \\back slash.";
 
         testSubject(subjectWithBackslashCharacter);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
@@ -1,12 +1,12 @@
 package com.icegreen.greenmail.imap.commands;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CommandParserTest {
+import org.junit.jupiter.api.Test;
+
+class CommandParserTest {
     @Test
-    public void test() {
+    void test() {
         assertThat(CommandParser.isCrOrLf('\n')).isTrue();
         assertThat(CommandParser.isCrOrLf('\r')).isTrue();
         assertThat(CommandParser.isCrOrLf('\t')).isFalse();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/IdRangeTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/IdRangeTest.java
@@ -2,7 +2,7 @@ package com.icegreen.greenmail.imap.commands;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.icegreen.greenmail.imap.commands.IdRange.VALUE_WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,9 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * See https://tools.ietf.org/html/rfc3501#page-53 regarding sequence-set
  */
-public class IdRangeTest {
+class IdRangeTest {
     @Test
-    public void testParseRangeSequence() {
+    void testParseRangeSequence() {
         String sequenceSetText = "1";
         assertThat(IdRange.SEQUENCE.matcher(sequenceSetText).matches()).isTrue();
         List<IdRange> sequenceSet = IdRange.parseRangeSequence(sequenceSetText);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -1,39 +1,48 @@
 package com.icegreen.greenmail.imap.commands;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.store.FolderException;
-import com.icegreen.greenmail.user.GreenMailUser;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import jakarta.mail.*;
-import jakarta.mail.internet.MimeMessage;
-import org.eclipse.angus.mail.iap.Argument;
-import org.eclipse.angus.mail.iap.ByteArray;
-import org.eclipse.angus.mail.iap.Response;
-import org.eclipse.angus.mail.imap.IMAPFolder;
-import org.eclipse.angus.mail.imap.IMAPStore;
-import org.eclipse.angus.mail.imap.protocol.*;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.angus.mail.iap.Argument;
+import org.eclipse.angus.mail.iap.ByteArray;
+import org.eclipse.angus.mail.iap.Response;
+import org.eclipse.angus.mail.imap.IMAPFolder;
+import org.eclipse.angus.mail.imap.IMAPStore;
+import org.eclipse.angus.mail.imap.protocol.BODY;
+import org.eclipse.angus.mail.imap.protocol.FetchResponse;
+import org.eclipse.angus.mail.imap.protocol.IMAPResponse;
+import org.eclipse.angus.mail.imap.protocol.RFC822SIZE;
+import org.eclipse.angus.mail.imap.protocol.UID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.user.GreenMailUser;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.NoSuchProviderException;
+import jakarta.mail.internet.MimeMessage;
 
 /**
  * Low level IMAP protocol test cases.
  */
-public class ImapProtocolTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class ImapProtocolTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
     private GreenMailUser user;
     private IMAPStore store;
 
-    @Before
-    public void beforeEachTest() throws NoSuchProviderException {
+    @BeforeEach
+    void beforeEachTest() throws NoSuchProviderException {
         user = greenMail.setUser("foo@localhost", "pwd");
 
         int numberOfMails = 10;
@@ -48,7 +57,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testListAndStatusWithNonExistingFolder() throws MessagingException {
+    void testListAndStatusWithNonExistingFolder() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -69,7 +78,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testFetchUidsAndSize() throws MessagingException {
+    void testFetchUidsAndSize() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -82,7 +91,7 @@ public class ImapProtocolTest {
 
             RFC822SIZE size = fetchResponse.getItem(RFC822SIZE.class);
             assertThat(size).isNotNull();
-            assertThat(size.size > 0).isTrue();
+            assertThat(size.size).isPositive();
 
             UID uid = fetchResponse.getItem(UID.class);
             assertThat(uid.uid).isEqualTo(folder.getUID(folder.getMessage(1)));
@@ -92,7 +101,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testFetchSpaceBeforeSize() throws MessagingException {
+    void testFetchSpaceBeforeSize() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -158,7 +167,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testSearchSequenceSet() throws MessagingException {
+    void testSearchSequenceSet() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -198,7 +207,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testUidSearchSequenceSet() throws MessagingException {
+    void testUidSearchSequenceSet() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -243,7 +252,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testSearchNotFlags() throws MessagingException {
+    void testSearchNotFlags() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -261,7 +270,7 @@ public class ImapProtocolTest {
 
 
     @Test
-    public void testGetMessageByUnknownUidInEmptyINBOX() throws MessagingException, FolderException {
+    void testGetMessageByUnknownUidInEmptyINBOX() throws MessagingException, FolderException {
         greenMail.getManagers()
             .getImapHostManager()
             .getInbox(user)
@@ -278,7 +287,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testUidSearchText() throws MessagingException {
+    void testUidSearchText() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -312,7 +321,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testRenameFolder() throws MessagingException {
+    void testRenameFolder() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -336,7 +345,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testDeleteInbox() throws MessagingException {
+    void testDeleteInbox() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -357,7 +366,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testRenameToExistedFolder() throws MessagingException {
+    void testRenameToExistedFolder() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
@@ -382,7 +391,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testUidSearchTextWithCharset() throws MessagingException, IOException {
+    void testUidSearchTextWithCharset() throws MessagingException, IOException {
         greenMail.setUser("foo2@localhost", "pwd");
         store.connect("foo2@localhost", "pwd");
         try {
@@ -430,7 +439,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testUidSearchAll() throws MessagingException {
+    void testUidSearchAll() throws MessagingException {
         greenMail.setUser("foo2@localhost", "pwd");
         store.connect("foo2@localhost", "pwd");
         try {
@@ -454,7 +463,7 @@ public class ImapProtocolTest {
     }
 
     @Test
-    public void testSelectMailFolder() throws MessagingException {
+    void testSelectMailFolder() throws MessagingException {
         greenMail.setUser("foo2@localhost", "pwd");
         store.connect("foo2@localhost", "pwd");
         try {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchCommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchCommandParserTest.java
@@ -1,21 +1,32 @@
 package com.icegreen.greenmail.imap.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.jupiter.api.Test;
+
 import com.icegreen.greenmail.imap.ImapRequestLineReader;
 import com.icegreen.greenmail.imap.ProtocolException;
 import jakarta.mail.Flags;
 import jakarta.mail.Message;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.search.*;
-import org.junit.Test;
+import jakarta.mail.search.AndTerm;
+import jakarta.mail.search.ComparisonTerm;
+import jakarta.mail.search.FlagTerm;
+import jakarta.mail.search.FromTerm;
+import jakarta.mail.search.HeaderTerm;
+import jakarta.mail.search.NotTerm;
+import jakarta.mail.search.OrTerm;
+import jakarta.mail.search.RecipientTerm;
+import jakarta.mail.search.SearchTerm;
+import jakarta.mail.search.SizeTerm;
+import jakarta.mail.search.SubjectTerm;
 
-import java.io.ByteArrayInputStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class SearchCommandParserTest {
+class SearchCommandParserTest {
     @Test
-    public void testHeader() throws ProtocolException {
+    void testHeader() throws ProtocolException {
         SearchTerm expectedTerm = new AndTerm(
             new AndTerm(new SearchTerm[]{
                 new HeaderTerm("Message-ID", "<1627010197.0.1593681191102@[192.168.242.10]>"),
@@ -30,7 +41,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testSmallerParseCommand() throws ProtocolException {
+    void testSmallerParseCommand() throws ProtocolException {
         SearchTerm expectedTerm = new SizeTerm(ComparisonTerm.LT, 5);
         SearchTerm searchTerm = parse("SMALLER 5");
 
@@ -38,7 +49,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testLargerParseCommand() throws ProtocolException {
+    void testLargerParseCommand() throws ProtocolException {
         SearchTerm expectedTerm = new SizeTerm(ComparisonTerm.GT, 5);
         SearchTerm searchTerm = parse("LARGER 5");
 
@@ -46,7 +57,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testSmallerAndLargerParseCommand() throws ProtocolException {
+    void testSmallerAndLargerParseCommand() throws ProtocolException {
         SearchTerm expectedTerm = new AndTerm(new SizeTerm(ComparisonTerm.LT, 5), new SizeTerm(ComparisonTerm.GT, 3));
         SearchTerm searchTerm = parse("SMALLER 5 LARGER 3");
 
@@ -54,7 +65,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testAndSubjectOrToFrom() throws ProtocolException, AddressException {
+    void testAndSubjectOrToFrom() throws ProtocolException, AddressException {
         SearchTerm expectedTerm = new AndTerm(new SearchTerm[]{
             new SubjectTerm("Greenmail"),
             new OrTerm(
@@ -70,7 +81,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testNotKeyword() throws ProtocolException {
+    void testNotKeyword() throws ProtocolException {
         Flags flags = new Flags();
         flags.add("ABC");
         SearchTerm expectedTerm = new NotTerm(new FlagTerm(flags, true));
@@ -80,7 +91,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testSimpleOr() throws ProtocolException {
+    void testSimpleOr() throws ProtocolException {
         SearchTerm expectedTerm = new OrTerm(
             new FlagTerm(new Flags(Flags.Flag.DRAFT), true),
             new FlagTerm(new Flags(Flags.Flag.SEEN), true)
@@ -91,7 +102,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testIssue591simple() throws ProtocolException {
+    void testIssue591simple() throws ProtocolException {
         SearchTerm expectedTerm = new OrTerm(
             new NotTerm(new FlagTerm(new Flags(Flags.Flag.SEEN), true)),
             new FlagTerm(new Flags(Flags.Flag.SEEN), true)
@@ -102,7 +113,7 @@ public class SearchCommandParserTest {
     }
 
     @Test
-    public void testIssue591complex() throws ProtocolException {
+    void testIssue591complex() throws ProtocolException {
         SearchTerm expectedTerm = new OrTerm(
             new NotTerm(new FlagTerm(new Flags(Flags.Flag.SEEN), true)),
             new OrTerm(

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchTermBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/SearchTermBuilderTest.java
@@ -1,13 +1,13 @@
 package com.icegreen.greenmail.imap.commands;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 
-public class SearchTermBuilderTest {
+class SearchTermBuilderTest {
     static class Data {
         String uidSeq;
         long[] uidMatching;
@@ -21,7 +21,7 @@ public class SearchTermBuilderTest {
     }
 
     @Test
-    public void testUidSearchTerm() {
+    void testUidSearchTerm() {
         Data[] data = new Data[]{
                 new Data("1", new long[]{1L}, new long[]{0L, 2L}),
                 new Data("1:*", new long[]{1L, 2L}, new long[]{0L}),

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
@@ -1,12 +1,6 @@
 package com.icegreen.greenmail.pop3;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.pop3.commands.AuthCommand;
-import com.icegreen.greenmail.user.UserException;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,18 +8,25 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class POP3CommandTest {
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.pop3.commands.AuthCommand;
+import com.icegreen.greenmail.user.UserException;
+import com.icegreen.greenmail.util.ServerSetupTest;
+
+class POP3CommandTest {
     private static final String CRLF = "\r\n";
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.POP3);
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.POP3);
 
     private int port;
     private String hostAddress;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         hostAddress = greenMail.getPop3().getBindTo();
         port = greenMail.getPop3().getPort();
@@ -49,7 +50,7 @@ public class POP3CommandTest {
     }
 
     @Test
-    public void authPlain() throws IOException {
+    void authPlain() throws IOException {
         withConnection((printStream, reader) -> {
             // No such user
             assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
@@ -74,7 +75,7 @@ public class POP3CommandTest {
     }
 
     @Test
-    public void authPlainWithContinuation() throws IOException, UserException {
+    void authPlainWithContinuation() throws IOException, UserException {
         greenMail.getUserManager()
                 .createUser("test@localhost", "test", "testpass");
         withConnection((printStream, reader) -> {
@@ -87,7 +88,7 @@ public class POP3CommandTest {
     }
 
     @Test
-    public void authDisabled() throws IOException {
+    void authDisabled() throws IOException {
         greenMail.getUserManager().setAuthRequired(false);
         withConnection((printStream, reader) -> {
             assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
@@ -97,7 +98,7 @@ public class POP3CommandTest {
     }
 
     @Test
-    public void authEnabled() throws IOException {
+    void authEnabled() throws IOException {
         greenMail.getUserManager().setAuthRequired(true);
         withConnection((printStream, reader) -> {
             assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/Pop3ServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/Pop3ServerTest.java
@@ -4,38 +4,38 @@
  */
 package com.icegreen.greenmail.pop3;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+
+import org.eclipse.angus.mail.pop3.POP3Folder;
+import org.eclipse.angus.mail.pop3.POP3Store;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.user.UserException;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.pop3.POP3Folder;
-import org.eclipse.angus.mail.pop3.POP3Store;
 import jakarta.mail.AuthenticationFailedException;
 import jakarta.mail.BodyPart;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMultipart;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.ByteArrayOutputStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Wael Chatila
  */
-public class Pop3ServerTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup[]{
+class Pop3ServerTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(new ServerSetup[]{
         ServerSetupTest.SMTP, ServerSetupTest.SMTPS,
         ServerSetupTest.POP3, ServerSetupTest.POP3S});
 
     @Test
-    public void testPop3Capabillities() throws MessagingException, UserException {
+    void testPop3Capabillities() throws MessagingException, UserException {
         final POP3Store store = greenMail.getPop3().createStore();
         greenMail.getUserManager().createUser("testPop3Capabillities@localhost",
                 "testPop3Capabillities@localhost", "pwd");
@@ -48,7 +48,7 @@ public class Pop3ServerTest {
     }
 
     @Test
-    public void testRetrieve() throws Exception {
+    void testRetrieve() throws Exception {
         assertThat(greenMail.getPop3()).isNotNull();
         final String subject = GreenMailUtil.random();
         final String body = GreenMailUtil.random() + "\r\n.\r\n"
@@ -71,7 +71,7 @@ public class Pop3ServerTest {
     }
 
     @Test
-    public void testPop3sReceive() throws Throwable {
+    void testPop3sReceive() throws Throwable {
         assertThat(greenMail.getPop3s()).isNotNull();
         final String subject = GreenMailUtil.random();
         final String body = GreenMailUtil.random();
@@ -88,7 +88,7 @@ public class Pop3ServerTest {
     }
 
     @Test
-    public void testRetrieveWithNonDefaultPassword() throws Exception {
+    void testRetrieveWithNonDefaultPassword() throws Exception {
         assertThat(greenMail.getPop3()).isNotNull();
         final String to = "test@localhost";
         final String password = "donotharmanddontrecipricateharm";
@@ -111,7 +111,7 @@ public class Pop3ServerTest {
     }
 
     @Test
-    public void testRetrieveMultipart() throws Exception {
+    void testRetrieveMultipart() throws Exception {
         assertThat(greenMail.getPop3()).isNotNull();
 
         String subject = GreenMailUtil.random();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/server/AllocateAvailablePortTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/server/AllocateAvailablePortTest.java
@@ -1,27 +1,27 @@
 package com.icegreen.greenmail.server;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.ServerSetup;
-import org.junit.Rule;
-import org.junit.Test;
-
-import jakarta.mail.internet.MimeMessage;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AllocateAvailablePortTest {
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetup.SMTP.dynamicPort());
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+import jakarta.mail.internet.MimeMessage;
+
+class AllocateAvailablePortTest {
+
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetup.SMTP.dynamicPort());
 
     @Test
-    public void returnTheActuallyAllocatedPort() {
+    void returnTheActuallyAllocatedPort() {
         assertThat(greenMail.getSmtp().getPort()).isNotZero();
     }
 
     @Test
-    public void ensureThatMailCanActuallyBeSentToTheAllocatedPort() {
+    void ensureThatMailCanActuallyBeSentToTheAllocatedPort() {
         GreenMailUtil.sendTextEmail("to@localhost", "from@localhost", "subject", "body",
                 greenMail.getSmtp().getServerSetup());
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/server/GreenMailBaseTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/server/GreenMailBaseTest.java
@@ -1,19 +1,19 @@
 package com.icegreen.greenmail.server;
 
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 /**
  * Base GreenMail test (no pre-configured GreenMail server)
  */
-public class GreenMailBaseTest {
+class GreenMailBaseTest {
     @Test
-    public void testCustomMailSessionProperties() {
+    void testCustomMailSessionProperties() {
         GreenMail greenMail = new GreenMail(new ServerSetup[]{
             ServerSetupTest.SMTP,
             ServerSetupTest.IMAP.mailSessionProperty("a.key","a.value")});

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/server/GreenMailTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/server/GreenMailTest.java
@@ -1,17 +1,18 @@
 package com.icegreen.greenmail.server;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.MimeMessageHelper;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.MimeMessageHelper;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.internet.MimeMessage;
 
 
 /**
@@ -19,12 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author smm
  */
-public class GreenMailTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class GreenMailTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testWaitForIncomingEmailWithTimeout() {
+    void testWaitForIncomingEmailWithTimeout() {
         long start = System.currentTimeMillis();
         final long timeout = 2000L;
         boolean mailReceived = greenMail.waitForIncomingEmail(timeout, 1);
@@ -37,7 +38,7 @@ public class GreenMailTest {
     }
 
     @Test
-    public void getReceivedMessagesForDomainLowerCaseRecipientAddress() {
+    void getReceivedMessagesForDomainLowerCaseRecipientAddress() {
         final String to = "to@localhost";
         GreenMailUtil.sendTextEmailTest(to, "from@localhost", "subject", "body");
 
@@ -46,7 +47,7 @@ public class GreenMailTest {
     }
 
     @Test
-    public void getReceivedMessagesForDomainWithUpperCaseRecipientAddress() {
+    void getReceivedMessagesForDomainWithUpperCaseRecipientAddress() {
         final String to = "someReceiver@localhost";
         GreenMailUtil.sendTextEmailTest(to, "from@localhost", "subject", "body");
 
@@ -55,7 +56,7 @@ public class GreenMailTest {
     }
 
     @Test
-    public void testFindReceivedMessages() {
+    void testFindReceivedMessages() {
         GreenMailUtil.sendTextEmailTest("foo@localhost", "from@localhost", "#1", "body");
         GreenMailUtil.sendTextEmailTest("foo@localhost", "from@localhost", "#2 match", "body"); // Should match
         GreenMailUtil.sendTextEmailTest("bar@localhost", "from@localhost", "#3 match", "body"); // Should match
@@ -80,7 +81,7 @@ public class GreenMailTest {
     }
 
     @Test
-    public void testIsRunning() {
+    void testIsRunning() {
         assertThat(greenMail.isRunning()).isTrue();
         greenMail.stop();
         assertThat(greenMail.isRunning()).isFalse();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
@@ -1,43 +1,43 @@
 package com.icegreen.greenmail.smtp;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.smtp.commands.AuthCommand;
-import com.icegreen.greenmail.user.UserException;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.smtp.SMTPTransport;
-import jakarta.mail.MessagingException;
-import jakarta.mail.Session;
-import jakarta.mail.URLName;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.angus.mail.smtp.SMTPTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.smtp.commands.AuthCommand;
+import com.icegreen.greenmail.user.UserException;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.URLName;
 
-public class SMTPCommandTest {
+class SMTPCommandTest {
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP);
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP);
 
     private int port;
     private String hostAddress;
     private URLName smtpURL;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         hostAddress = greenMail.getSmtp().getBindTo();
         port = greenMail.getSmtp().getPort();
         smtpURL = new URLName(hostAddress);
     }
 
     @Test
-    public void mailSenderEmpty() throws IOException, MessagingException {
+    void mailSenderEmpty() throws IOException, MessagingException {
         Session smtpSession = greenMail.getSmtp().createSession();
 
         try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {
@@ -50,7 +50,7 @@ public class SMTPCommandTest {
     }
 
     @Test
-    public void authPlain() throws IOException, MessagingException, UserException {
+    void authPlain() throws IOException, MessagingException, UserException {
         {
             Session smtpSession = greenMail.getSmtp().createSession();
             try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {
@@ -86,7 +86,7 @@ public class SMTPCommandTest {
     }
 
     @Test
-    public void authLogin() throws IOException, MessagingException, UserException {
+    void authLogin() throws IOException, MessagingException, UserException {
         Session smtpSession = greenMail.getSmtp().createSession();
         try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {
             Socket smtpSocket = new Socket(hostAddress, port); // Closed by transport
@@ -113,7 +113,7 @@ public class SMTPCommandTest {
     }
 
     @Test
-    public void mailSenderAUTHSuffix() throws IOException, MessagingException {
+    void mailSenderAUTHSuffix() throws IOException, MessagingException {
         Session smtpSession = greenMail.getSmtp().createSession();
 
         try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpSecureServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpSecureServerTest.java
@@ -1,22 +1,22 @@
 package com.icegreen.greenmail.smtp;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.internet.MimeMessage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class SmtpSecureServerTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup[]{ServerSetupTest.SMTPS});
+class SmtpSecureServerTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(new ServerSetup[]{ServerSetupTest.SMTPS});
 
     @Test
-    public void testSmtpsServerReceive() throws Throwable {
+    void testSmtpsServerReceive() throws Throwable {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         String subject = GreenMailUtil.random();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpServerTest.java
@@ -4,7 +4,19 @@
  */
 package com.icegreen.greenmail.smtp;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static com.icegreen.greenmail.util.GreenMailUtil.createTextEmail;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.Properties;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.smtp.commands.AuthCommand;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMailUtil;
@@ -20,29 +32,18 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMessage.RecipientType;
 import jakarta.mail.internet.MimeMultipart;
-import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.SocketException;
-import java.util.Properties;
-
-import static com.icegreen.greenmail.util.GreenMailUtil.createTextEmail;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Wael Chatila
  * @version $Id: $
  * @since Jan 28, 2006
  */
-public class SmtpServerTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup[]{ServerSetupTest.SMTP});
+class SmtpServerTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(new ServerSetup[]{ServerSetupTest.SMTP});
 
     @Test
-    public void testSmtpServerBasic() throws MessagingException, IOException {
+    void testSmtpServerBasic() throws MessagingException, IOException {
         GreenMailUtil.sendTextEmailTest("to@localhost", "from@localhost", "subject", "body");
         MimeMessage[] emails = greenMail.getReceivedMessages();
         assertThat(emails).hasSize(1);
@@ -51,7 +52,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSmtpServerTimeout() {
+    void testSmtpServerTimeout() {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
         long t0 = System.currentTimeMillis();
         greenMail.waitForIncomingEmail(500, 1);
@@ -61,7 +62,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSmtpServerReceiveWithSetup() throws Throwable {
+    void testSmtpServerReceiveWithSetup() throws Throwable {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         String subject = GreenMailUtil.random();
@@ -76,7 +77,7 @@ public class SmtpServerTest {
 
 
     @Test
-    public void testSmtpServerReceiveInThread() throws Throwable {
+    void testSmtpServerReceiveInThread() throws Throwable {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         Thread sendThread = new Thread(() -> {
@@ -95,7 +96,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSmtpServerReceiveMultipart() throws Exception {
+    void testSmtpServerReceiveMultipart() throws Exception {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         String subject = GreenMailUtil.random();
@@ -127,7 +128,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSmtpServerLeadingPeriods() throws MessagingException, IOException {
+    void testSmtpServerLeadingPeriods() throws MessagingException, IOException {
         String body = ". body with leading period";
         GreenMailUtil.sendTextEmailTest("to@localhost", "from@localhost", "subject", body);
         MimeMessage[] emails = greenMail.getReceivedMessages();
@@ -137,7 +138,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSendAndWaitForIncomingMailsInBcc() throws Throwable {
+    void testSendAndWaitForIncomingMailsInBcc() throws Throwable {
         String subject = GreenMailUtil.random();
         String body = GreenMailUtil.random();
         final MimeMessage message = createTextEmail("test@localhost", "from@localhost", subject, body,
@@ -155,7 +156,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSendWithReusedConnection() throws Throwable {
+    void testSendWithReusedConnection() throws Throwable {
         String subject = GreenMailUtil.random();
         String body = GreenMailUtil.random();
         final MimeMessage message = createTextEmail("test@localhost", "from@localhost", subject, body,
@@ -190,7 +191,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testAuth() throws Throwable {
+    void testAuth() throws Throwable {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         String subject = GreenMailUtil.random();
@@ -216,7 +217,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSmtpServerReceiveWithAUTHSuffix() throws Throwable {
+    void testSmtpServerReceiveWithAUTHSuffix() throws Throwable {
         assertThat(greenMail.getReceivedMessages()).isEmpty();
 
         String subject = GreenMailUtil.random();
@@ -242,7 +243,7 @@ public class SmtpServerTest {
     }
 
     @Test
-    public void testSendAndReCreateUser() throws MessagingException {
+    void testSendAndReCreateUser() throws MessagingException {
         GreenMailUser user = greenMail.setUser("foo@localhost", "pwd");
         GreenMailUtil.sendTextEmail(user.getEmail(), user.getEmail(), "Test subject",
             "Test message", greenMail.getSmtp().getServerSetup());

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/DateTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/DateTest.java
@@ -1,31 +1,32 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.server.AbstractServer;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.Retriever;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.mail.Message;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.server.AbstractServer;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.Retriever;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 /**
  * Tests date handling for received messages
  */
-public class DateTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+class DateTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP);
 
     @Test
-    public void testDatesCorrect() throws MessagingException {
+    void testDatesCorrect() throws MessagingException {
         String to = "to@localhost";
         greenMail.setUser(to, to);
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/EncodingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/EncodingTest.java
@@ -1,11 +1,22 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.eclipse.angus.mail.imap.IMAPFolder;
+import org.eclipse.angus.mail.imap.IMAPStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.EncodingUtil;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.imap.IMAPFolder;
-import org.eclipse.angus.mail.imap.IMAPStore;
 import jakarta.mail.BodyPart;
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
@@ -19,22 +30,13 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.internet.MimeUtility;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for encoding scenarios.
  */
-public class EncodingTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class EncodingTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     /**
      * Structure of test message and content type:
@@ -43,7 +45,7 @@ public class EncodingTest {
      * \--> Message (text/plain)
      */
     @Test
-    public void testTextPlainWithUTF8() throws MessagingException, IOException {
+    void testTextPlainWithUTF8() throws MessagingException, IOException {
         greenMail.setUser("foo@localhost", "pwd");
         final Session session = greenMail.getSmtp().createSession();
 
@@ -124,7 +126,7 @@ public class EncodingTest {
     }
 
     @Test
-    public void testTextPlainWithUTF8AndGreenMailApi() throws MessagingException, IOException {
+    void testTextPlainWithUTF8AndGreenMailApi() throws MessagingException, IOException {
         String content = "This is a test with ünicöde: \uD83C\uDF36";
         String subject = "Some sübject";
 
@@ -139,8 +141,9 @@ public class EncodingTest {
         assertThat(msg.getContent()).isEqualTo(content);
     }
 
-    @Test(timeout = 10000)
-    public void testTextPlainWithUTF8SenderAndReceiverAndGreenMailApi() throws MessagingException, IOException {
+    @Test
+    @Timeout(10000)
+    void testTextPlainWithUTF8SenderAndReceiverAndGreenMailApi() throws MessagingException, IOException {
         // this intermediate `InternetAddress` is needed because of:
         // https://stackoverflow.com/questions/31859901/java-mail-sender-address-gets-non-ascii-chars-removed/31865820#31865820
         InternetAddress address = new InternetAddress("\"кирилица\" <to@localhost>");
@@ -211,7 +214,7 @@ public class EncodingTest {
     }
 
     @Test
-    public void testAttachmentWithLongEncodedUTF8Name() throws MessagingException, IOException {
+    void testAttachmentWithLongEncodedUTF8Name() throws MessagingException, IOException {
         // Prepare mail
         greenMail.setUser("to@localhost", "pwd");
         String fileName = "кирилица testimage_ünicöde_\uD83C\uDF36";

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/EscapingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/EscapingTest.java
@@ -1,29 +1,29 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.server.AbstractServer;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import jakarta.mail.internet.MimeMessage;
 
 /**
  * Tests escaping of message parts
  */
-public class EscapingTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+class EscapingTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP);
 
     @Test
-    public void testEscapeSubject() throws MessagingException {
+    void testEscapeSubject() throws MessagingException {
         String to = "to@localhost";
         String subject = "Subject?<>/|\\\\.%\\\"*?:{[]}!";
         greenMail.setUser(to, to);
@@ -36,7 +36,7 @@ public class EscapingTest {
     }
 
     @Test
-    public void testEscapeMessageID() throws MessagingException {
+    void testEscapeMessageID() throws MessagingException {
         String to = "foo@localhost";
         String from = "bar`bar <bar@localhost>";
         String subject = "Bad IMAP Envelope";

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/LargeMessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/LargeMessageTest.java
@@ -1,33 +1,34 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
-import com.icegreen.greenmail.server.AbstractServer;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.Retriever;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.mail.BodyPart;
-import jakarta.mail.Message;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMultipart;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.server.AbstractServer;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.Retriever;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMultipart;
 
 /**
  * Tests sending and receiving large messages
  */
-public class LargeMessageTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+class LargeMessageTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP);
 
     @Test
-    public void testLargeMessageTextAndAttachment() throws MessagingException, IOException {
+    void testLargeMessageTextAndAttachment() throws MessagingException, IOException {
         String to = "to@localhost";
         GreenMailUtil.sendAttachmentEmail(to, "from@localhost", "Subject", createLargeString(),
             createLargeByteArray(), "application/blubb", "file", "descr",
@@ -39,7 +40,7 @@ public class LargeMessageTest {
     }
 
     @Test
-    public void testLargeMessageBody() throws MessagingException, IOException {
+    void testLargeMessageBody() throws MessagingException, IOException {
         String to = "to@localhost";
         GreenMailUtil.sendMessageBody(to, "from@localhost", "Subject", createLargeByteArray(), "application/blubb",
             greenMail.getSmtp().getServerSetup());

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/ReplyToTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/ReplyToTest.java
@@ -1,6 +1,13 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.server.AbstractServer;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.Retriever;
@@ -11,19 +18,13 @@ import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.UnsupportedEncodingException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests if ReplyTo addresses of received messages are set correctly.
  */
-public class ReplyToTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_POP3_IMAP);
+class ReplyToTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_POP3_IMAP);
 
     private static final InternetAddress[] TO_ADDRESSES;
     private static final InternetAddress[] CC_ADDRESSES;
@@ -56,7 +57,7 @@ public class ReplyToTest {
     }
 
     @Test
-    public void testReplyToFromAddress() throws MessagingException {
+    void testReplyToFromAddress() throws MessagingException {
         UserUtil.createUsers(greenMail, TO_ADDRESSES);
         UserUtil.createUsers(greenMail, CC_ADDRESSES);
         UserUtil.createUsers(greenMail, BCC_ADDRESSES);
@@ -73,18 +74,18 @@ public class ReplyToTest {
         greenMail.waitForIncomingEmail(5000, 1);
 
         for (InternetAddress address : TO_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, FROM_ADDRESS);
+            retrieveAndCheckReplyTo(address, FROM_ADDRESS);
         }
         for (InternetAddress address : CC_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, FROM_ADDRESS);
+            retrieveAndCheckReplyTo(address, FROM_ADDRESS);
         }
         for (InternetAddress address : BCC_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, FROM_ADDRESS);
+            retrieveAndCheckReplyTo(address, FROM_ADDRESS);
         }
     }
 
     @Test
-    public void testReplyToSpecificAddress() throws MessagingException {
+    void testReplyToSpecificAddress() throws MessagingException {
         UserUtil.createUsers(greenMail, TO_ADDRESSES);
         UserUtil.createUsers(greenMail, CC_ADDRESSES);
         UserUtil.createUsers(greenMail, BCC_ADDRESSES);
@@ -102,23 +103,22 @@ public class ReplyToTest {
         greenMail.waitForIncomingEmail(5000, 1);
 
         for (InternetAddress address : TO_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, REPLY_TO_ADDRESSES);
+            retrieveAndCheckReplyTo(address, REPLY_TO_ADDRESSES);
         }
         for (InternetAddress address : CC_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, REPLY_TO_ADDRESSES);
+            retrieveAndCheckReplyTo(address, REPLY_TO_ADDRESSES);
         }
         for (InternetAddress address : BCC_ADDRESSES) {
-            retrieveAndCheckReplyTo(greenMail, address, REPLY_TO_ADDRESSES);
+            retrieveAndCheckReplyTo(address, REPLY_TO_ADDRESSES);
         }
     }
 
     /**
      * Retrieve mail through IMAP and POP3 and check sender and receivers
      *
-     * @param greenMail Greenmail instance to read from
-     * @param addr      Address of account to retrieve
+     * @param addr Address of account to retrieve
      */
-    private void retrieveAndCheckReplyTo(GreenMailRule greenMail, InternetAddress addr, InternetAddress... replyToAddrs)
+    private void retrieveAndCheckReplyTo(InternetAddress addr, InternetAddress... replyToAddrs)
             throws MessagingException {
         String address = addr.getAddress();
         retrieveAndCheckReplyTo(greenMail.getPop3(), address, replyToAddrs);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/Rfc822MessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/specificmessages/Rfc822MessageTest.java
@@ -1,20 +1,25 @@
 package com.icegreen.greenmail.specificmessages;
 
-import com.icegreen.greenmail.junit.GreenMailRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.eclipse.angus.mail.imap.IMAPStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetupTest;
-import org.eclipse.angus.mail.imap.IMAPStore;
-import org.junit.Rule;
-import org.junit.Test;
-
-import jakarta.mail.*;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests forwarding an email.
@@ -22,9 +27,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * See https://github.com/greenmail-mail-test/greenmail/issues/142
  * See http://www.oracle.com/technetwork/java/faq-135477.html#forward
  */
-public class Rfc822MessageTest {
-    @Rule
-    public GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class Rfc822MessageTest {
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     /**
      * Structure of test message and content type:
@@ -35,7 +40,7 @@ public class Rfc822MessageTest {
      * \--> Message (text/plain)
      */
     @Test
-    public void testForwardWithRfc822() throws MessagingException, IOException {
+    void testForwardWithRfc822() throws MessagingException, IOException {
         greenMail.setUser("foo@localhost", "pwd");
         final Session session = greenMail.getSmtp().createSession();
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
@@ -10,7 +10,7 @@ import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 
-public class UserManagerTest {
+class UserManagerTest {
     @Test
-    public void testListUsers() throws UserException {
+    void testListUsers() throws UserException {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
 
@@ -40,7 +40,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testFindByEmailAndLogin() throws UserException {
+    void testFindByEmailAndLogin() throws UserException {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
         GreenMailUser u1 = userManager.createUser("foo@bar.com", "foo", "pwd");
@@ -67,7 +67,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testCreateAndDeleteUser() throws UserException {
+    void testCreateAndDeleteUser() throws UserException {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
 
@@ -81,7 +81,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testDeleteUserShouldDeleteMail() throws Exception {
+    void testDeleteUserShouldDeleteMail() throws Exception {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
 
@@ -105,7 +105,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testNoAuthRequired() {
+    void testNoAuthRequired() {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(false);
@@ -115,7 +115,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testNoAuthRequiredWithExistingUser() throws UserException {
+    void testNoAuthRequiredWithExistingUser() throws UserException {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(false);
@@ -126,7 +126,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testAuthRequired() {
+    void testAuthRequired() {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(true);
@@ -136,7 +136,7 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testAuthRequiredWithExistingUser() throws UserException {
+    void testAuthRequiredWithExistingUser() throws UserException {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);
         userManager.setAuthRequired(true);
@@ -147,13 +147,13 @@ public class UserManagerTest {
     }
 
     @Test
-    public void testMultithreadedUserCreationAndDeletionWithSync() {
+    void testMultithreadedUserCreationAndDeletionWithSync() {
         ConcurrencyTest concurrencyTest = new ConcurrencyTest(true);
         concurrencyTest.performTest();
     }
 
     @Test
-    public void testMultithreadedUserCreationAndDeletion() {
+    void testMultithreadedUserCreationAndDeletion() {
         ConcurrencyTest concurrencyTest = new ConcurrencyTest(false);
         concurrencyTest.performTest();
     }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/GreenMailUtilTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/GreenMailUtilTest.java
@@ -16,7 +16,7 @@ import jakarta.mail.Quota;
 import jakarta.mail.Store;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 
@@ -27,22 +27,22 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @version $Id: $
  * @since Jan 29, 2006
  */
-public class GreenMailUtilTest {
+class GreenMailUtilTest {
     @Test
-    public void testMimeMessageLoading() throws MessagingException {
+    void testMimeMessageLoading() throws MessagingException {
         MimeMessage message = GreenMailUtil.newMimeMessage(SAMPLE_EMAIL);
         assertThat(message.getSubject()).isEqualTo("wassup");
     }
 
     @Test
-    public void testGetBody() {
+    void testGetBody() {
         MimeMessage message = GreenMailUtil.newMimeMessage(SAMPLE_EMAIL);
         String body = GreenMailUtil.getBody(message);
         assertThat(body.trim()).isEqualTo("Yo wassup Bertil");
     }
 
     @Test
-    public void testGetEmptyBodyAndHeader() throws Exception {
+    void testGetEmptyBodyAndHeader() throws Exception {
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
         try {
             greenMail.start();
@@ -84,7 +84,7 @@ public class GreenMailUtilTest {
     }
 
     @Test
-    public void testSendTextEmailTest() throws Exception {
+    void testSendTextEmailTest() throws Exception {
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
         try {
             greenMail.setUser("foo@localhost", "pwd");
@@ -119,7 +119,7 @@ public class GreenMailUtilTest {
     }
 
     @Test
-    public void testSetAndGetQuota() throws MessagingException {
+    void testSetAndGetQuota() throws MessagingException {
         GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP);
         try {
             greenMail.start();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/MaxSizeLinkedHashMapTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/MaxSizeLinkedHashMapTest.java
@@ -1,27 +1,28 @@
 package com.icegreen.greenmail.util;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class MaxSizeLinkedHashMapTest {
+class MaxSizeLinkedHashMapTest {
     private static final int TEST_MAX_SIZE = 8;
     private final MaxSizeLinkedHashMap<Integer, Integer> map = new MaxSizeLinkedHashMap<>(TEST_MAX_SIZE);
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldRejectNegativeMaxSize() {
-        new MaxSizeLinkedHashMap<>(-1 * Math.abs(new Random().nextInt(Integer.MAX_VALUE - 1) + 1));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldRejectZeroMaxSize() {
-        new MaxSizeLinkedHashMap<>(0);
+    @Test
+    void shouldRejectNegativeMaxSize() {
+        int maxSize =  -1 * Math.abs(new Random().nextInt(Integer.MAX_VALUE - 1) + 1);
+        assertThatThrownBy(() -> new MaxSizeLinkedHashMap<>(maxSize)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void shouldRejectLessThanZeroMaxSize() {
+    void shouldRejectZeroMaxSize() {
+        assertThatThrownBy(() -> new MaxSizeLinkedHashMap<>(0)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectLessThanZeroMaxSize() {
         try {
             new MaxSizeLinkedHashMap<>(-1);
         } catch (IllegalArgumentException ex) {
@@ -30,7 +31,7 @@ public class MaxSizeLinkedHashMapTest {
     }
 
     @Test
-    public void shouldNotExceedMaxSize() {
+    void shouldNotExceedMaxSize() {
         // When
         for (int i = 0; i < TEST_MAX_SIZE * 2; i++) {
             map.put(i, i);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/PreLoadEmailsTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/PreLoadEmailsTest.java
@@ -1,28 +1,29 @@
 package com.icegreen.greenmail.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+
+import org.eclipse.angus.mail.imap.IMAPStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.icegreen.greenmail.imap.ImapConstants;
 import com.icegreen.greenmail.imap.ImapServer;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.store.FolderException;
 import com.icegreen.greenmail.user.GreenMailUser;
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
-import org.eclipse.angus.mail.imap.IMAPStore;
-import org.junit.Rule;
-import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.FileSystems;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class PreLoadEmailsTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP);
+class PreLoadEmailsTest {
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
 
     @Test
-    public void testPreloadFromDirectory() throws IOException, MessagingException, FolderException {
+    void testPreloadFromDirectory() throws IOException, MessagingException, FolderException {
         /* Expected structure:
             preload
             ├── bar@localhost

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/PropertiesBasedServerSetupBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/PropertiesBasedServerSetupBuilderTest.java
@@ -1,15 +1,15 @@
 package com.icegreen.greenmail.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class PropertiesBasedServerSetupBuilderTest {
+class PropertiesBasedServerSetupBuilderTest {
     @Test
-    public void testCreate() {
+    void testCreate() {
         Properties properties = new Properties();
 
         properties.setProperty("greenmail.setup.all", "");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/RetrieverTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/RetrieverTest.java
@@ -1,14 +1,16 @@
 package com.icegreen.greenmail.util;
 
 import com.icegreen.greenmail.junit.GreenMailRule;
-import org.junit.Rule;
-import org.junit.Test;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.fail;
 
-public class RetrieverTest {
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(new ServerSetup[]{
+class RetrieverTest {
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(new ServerSetup[]{
             ServerSetupTest.IMAP,
             ServerSetupTest.IMAPS,
             ServerSetupTest.SMTP,
@@ -18,7 +20,7 @@ public class RetrieverTest {
     });
 
     @Test
-    public void testCreateRetriever() {
+    void testCreateRetriever() {
         try(Retriever r = new Retriever(greenMail.getImap())) {}
         try(Retriever r = new Retriever(greenMail.getImaps())) {}
         try(Retriever r = new Retriever(greenMail.getPop3())) {}
@@ -35,10 +37,12 @@ public class RetrieverTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructorWithNullArg() {
+    @Test
+    void testConstructorWithNullArg() {
         try( Retriever retriever = new Retriever(null)) {
-            // Nothing
+            fail("Expected IAE");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslMessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslMessageTest.java
@@ -1,13 +1,13 @@
 package com.icegreen.greenmail.util;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SaslMessageTest {
+class SaslMessageTest {
     @Test
-    public void testParse() {
+    void testParse() {
         final SaslMessage saslMessage = SaslMessage.parse("authzid\u0000authcid\u0000passwd");
         assertThat(saslMessage.getAuthzid()).isEqualTo("authzid");
         assertThat(saslMessage.getAuthcid()).isEqualTo("authcid");
@@ -15,7 +15,7 @@ public class SaslMessageTest {
     }
 
     @Test
-    public void testParseWithouthAuthzid() {
+    void testParseWithouthAuthzid() {
         final SaslMessage saslMessage = SaslMessage.parse("\u0000authcid\u0000passwd");
         assertThat(saslMessage.getAuthzid()).isEmpty();
         assertThat(saslMessage.getAuthcid()).isEqualTo("authcid");

--- a/greenmail-docker/standalone/pom.xml
+++ b/greenmail-docker/standalone/pom.xml
@@ -42,8 +42,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/greenmail-docker/standalone/src/test/java/com/icegreen/greenmail/docker/DockerServiceIT.java
+++ b/greenmail-docker/standalone/src/test/java/com/icegreen/greenmail/docker/DockerServiceIT.java
@@ -12,19 +12,19 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DockerServiceIT {
+class DockerServiceIT {
 
     private final String bindAddress = System.getProperty("greenmail.host.address", "127.0.0.1");
 
     @Test
-    public void testAllServices() throws MessagingException, InterruptedException {
+    void testAllServices() throws MessagingException, InterruptedException {
         // Ugly workaround : GreenMail in docker starts with open TCP connections,
         //                   but TLS sockets might not be ready yet.
         TimeUnit.SECONDS.sleep(1);

--- a/greenmail-spring/pom.xml
+++ b/greenmail-spring/pom.xml
@@ -33,8 +33,8 @@
 
     <!-- Test scope -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/greenmail-spring/src/test/java/com/icegreen/greenmail/spring/GreenMailBeanTest.java
+++ b/greenmail-spring/src/test/java/com/icegreen/greenmail/spring/GreenMailBeanTest.java
@@ -1,14 +1,14 @@
 package com.icegreen.greenmail.spring;
 
-import com.icegreen.greenmail.util.GreenMail;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import static com.icegreen.greenmail.spring.GreenMailBeanDefinitionParser.DEFAULT_SERVER_STARTUP_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.icegreen.greenmail.util.GreenMail;
 
 /**
  * Tests GreenMailBean.
@@ -16,13 +16,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marcel May (mm)
  */
 @ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class GreenMailBeanTest {
+@SpringJUnitConfig
+class GreenMailBeanTest {
     @Autowired
     private GreenMailBean greenMailBean;
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         GreenMail greenMail = greenMailBean.getGreenMail();
 
         // Test if the protocol got activated

--- a/greenmail-spring/src/test/java/com/icegreen/greenmail/spring/GreenMailNamespaceHandlerTest.java
+++ b/greenmail-spring/src/test/java/com/icegreen/greenmail/spring/GreenMailNamespaceHandlerTest.java
@@ -1,12 +1,11 @@
 package com.icegreen.greenmail.spring;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static com.icegreen.greenmail.spring.GreenMailBeanDefinitionParser.DEFAULT_SERVER_STARTUP_TIMEOUT;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import static com.icegreen.greenmail.spring.GreenMailBeanDefinitionParser.DEFAULT_SERVER_STARTUP_TIMEOUT;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * Tests GreenMailBean configured via xml namespace handler.
@@ -14,13 +13,13 @@ import static com.icegreen.greenmail.spring.GreenMailBeanDefinitionParser.DEFAUL
  * @author Marcel May (mm)
  */
 @ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class GreenMailNamespaceHandlerTest {
+@SpringJUnitConfig
+class GreenMailNamespaceHandlerTest {
     @Autowired
     private GreenMailBean greenMailBean;
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         assert null!= greenMailBean;
         assert "127.0.0.1".equals(greenMailBean.getHostname());
         assert greenMailBean.getPortOffset() == 5000;

--- a/greenmail-standalone/pom.xml
+++ b/greenmail-standalone/pom.xml
@@ -33,8 +33,8 @@
     </dependency>
     <!-- Test scope -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/greenmail-standalone/src/test/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunnerTest.java
+++ b/greenmail-standalone/src/test/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunnerTest.java
@@ -1,37 +1,45 @@
 package com.icegreen.greenmail.standalone;
 
-import com.icegreen.greenmail.configuration.PropertiesBasedGreenMailConfigurationBuilder;
-import com.icegreen.greenmail.util.GreenMailUtil;
-import com.icegreen.greenmail.util.PropertiesBasedServerSetupBuilder;
-import com.icegreen.greenmail.util.ServerSetupTest;
-import jakarta.mail.*;
-import jakarta.ws.rs.ProcessingException;
-import jakarta.ws.rs.client.*;
-import jakarta.ws.rs.core.GenericType;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import org.junit.After;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public class GreenMailStandaloneRunnerTest {
+import com.icegreen.greenmail.configuration.PropertiesBasedGreenMailConfigurationBuilder;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.PropertiesBasedServerSetupBuilder;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+class GreenMailStandaloneRunnerTest {
     private GreenMailStandaloneRunner runner;
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         if (null != runner) {
             runner.stop();
         }
     }
 
     @Test
-    public void testDoRun() throws MessagingException {
+    void testDoRun() throws MessagingException {
         runner = createAndConfigureRunner(new Properties());
 
         GreenMailUtil.sendTextEmail("test2@localhost", "test1@localhost",
@@ -57,7 +65,7 @@ public class GreenMailStandaloneRunnerTest {
     }
 
     @Test
-    public void testApi() {
+    void testApi() {
         final Properties properties = new Properties();
         properties.put(GreenMailApiServerBuilder.GREENMAIL_API_HOSTNAME, "localhost");
         runner = createAndConfigureRunner(properties);

--- a/greenmail-webapp/pom.xml
+++ b/greenmail-webapp/pom.xml
@@ -46,8 +46,8 @@
 
     <!-- Test scope -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/greenmail-webapp/src/test/java/com/icegreen/greenmail/webapp/ConfigurationFactoryTest.java
+++ b/greenmail-webapp/src/test/java/com/icegreen/greenmail/webapp/ConfigurationFactoryTest.java
@@ -1,18 +1,18 @@
 package com.icegreen.greenmail.webapp;
 
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * Test for ConfigurationFactory.
  */
-public class ConfigurationFactoryTest {
+class ConfigurationFactoryTest {
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         Map<String, String> paramValues = new HashMap<>();
         paramValues.put("greenmail.defaultHostname", "127.0.0.1");
         paramValues.put("greenmail.portOffset", "20000");

--- a/greenmail-webapp/src/test/java/com/icegreen/greenmail/webapp/GreenMailListenerTest.java
+++ b/greenmail-webapp/src/test/java/com/icegreen/greenmail/webapp/GreenMailListenerTest.java
@@ -3,7 +3,7 @@ package com.icegreen.greenmail.webapp;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import org.easymock.EasyMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Enumeration;
@@ -16,10 +16,10 @@ import static org.easymock.EasyMock.eq;
 /**
  * Test for GreenMailListener.
  */
-public class GreenMailListenerTest {
+class GreenMailListenerTest {
 
     @Test
-    public void testStart() {
+    void testStart() {
         Map<String, String> paramValues = new HashMap<>();
         paramValues.put("greenmail.defaultHostname", "127.0.0.1");
         paramValues.put("greenmail.portOffset", "20000");


### PR DESCRIPTION
the goal of this PR is to migrate all test-case in JUnit 5.

`GreenMailRule` in the core module is however not removed, but could now be done