### PR TITLE
 Modify regex in the RcptCommand class to allow adding parameters.

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/RcptCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/RcptCommand.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  */
 public class RcptCommand
         extends SmtpCommand {
-    static Pattern param = Pattern.compile("RCPT TO:\\s?<([^>]+)>",
+    static Pattern param = Pattern.compile("RCPT TO:\\s?<([^>]*)>.*",
             Pattern.CASE_INSENSITIVE);
 
     @Override

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
@@ -125,4 +125,18 @@ public class SMTPCommandTest {
         }
     }
 
+    
+    @Test
+    public void rcptToWithParameter() throws IOException, MessagingException {
+        Session smtpSession = greenMail.getSmtp().createSession();
+
+        try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {
+            Socket smtpSocket = new Socket(hostAddress, port); // Closed by transport
+            smtpTransport.connect(smtpSocket);
+            assertThat(smtpTransport.isConnected()).isTrue();
+            smtpTransport.issueCommand("MAIL FROM: <test.test@test.net>", -1);
+            smtpTransport.issueCommand("RCPT TO: <test@localhost> NOTIFY=SUCCESS,FAILURE", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("250 OK");
+        }
+    }
 }


### PR DESCRIPTION
Hello! I’ve been using GreenMail useful.

While using it, I noticed one area that could be improved, so I’m submitting this PR to address it.

According to [[RFC 2821 Section 4.1.1.3]](https://datatracker.ietf.org/doc/html/rfc2821.html#section-4.1.1.3) mentioned in the Java docs, the RCPT TO command, like the MAIL command, can accept parameters.

However, currently, an error occurs when parameters are added as shown below.

```
issueCommand : "RCPT TO: <test@localhost> NOTIFY=SUCCESS,FAILURE"

expect: "250 OK"
actual : "501 Required syntax: 'RCPT TO:<email@host>'"
```

In my case, I am customizing the SMTPTransport to include custom parameters, but errors occur every time a parameter is added.

I would greatly appreciate it if you could allow changing the regular expression used in the MAILCommand class to accommodate this!