### PR TITLE
Fix Incoming Message Duplication for Identical Receipients

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MailAddress.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MailAddress.java
@@ -7,6 +7,8 @@
 package com.icegreen.greenmail.mail;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Objects;
+
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeUtility;
 
@@ -72,5 +74,47 @@ public class MailAddress {
         } catch (UnsupportedEncodingException e) {
             return str;
         }
+    }
+
+    /**
+     * Compares this MailAddress object to another for equality.
+     * Two MailAddress objects are considered equal if their email, host, and user parts
+     * are equal, ignoring case.
+     * <p>
+     * The name field was not considered in the equality check.
+     *
+     * @param object The object to compare with.
+     * @return True if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object object) {
+
+        if (object instanceof MailAddress) {
+            MailAddress otherMailAddress = (MailAddress) object;
+
+            boolean emailsAreEqual = email.equalsIgnoreCase(otherMailAddress.getEmail());
+            boolean hostsAreEqual = host.equalsIgnoreCase(otherMailAddress.getHost());
+            boolean usersAreEqual = user.equalsIgnoreCase(otherMailAddress.getUser());
+
+            return emailsAreEqual && hostsAreEqual && usersAreEqual;
+        }
+
+        return false;
+    }
+
+    /**
+     * Computes the hash code for this MailAddress object.
+     * The hash code is based on the name, host, user, and email fields.
+     *
+     * @return The hash code for this MailAddress object.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            name != null ? name : "",
+            host != null ? host : "",
+            user != null ? user : "",
+            email != null ? email : ""
+        );
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MovingMessage.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/mail/MovingMessage.java
@@ -6,13 +6,13 @@
  */
 package com.icegreen.greenmail.mail;
 
-import jakarta.mail.internet.MimeMessage;
-import java.util.LinkedList;
-import java.util.List;
-
 import com.icegreen.greenmail.smtp.auth.AuthenticationState;
 import com.icegreen.greenmail.smtp.auth.LoginAuthenticationState;
 import com.icegreen.greenmail.smtp.auth.PlainAuthenticationState;
+import jakarta.mail.internet.MimeMessage;
+
+import java.util.HashSet;
+import java.util.Set;
 
 
 /**
@@ -21,7 +21,7 @@ import com.icegreen.greenmail.smtp.auth.PlainAuthenticationState;
 public class MovingMessage {
     private AuthenticationState authenticationState;
     private MailAddress returnPath;
-    private final List<MailAddress> toAddresses = new LinkedList<>();
+    private final Set<MailAddress> toAddresses = new HashSet<>();
     private MimeMessage message;
 
     /**
@@ -56,7 +56,7 @@ public class MovingMessage {
      * addresses from the mail header.
      * @return The address to which the mail is directed.
      */
-    public List<MailAddress> getToAddresses() {
+    public Set<MailAddress> getToAddresses() {
         return toAddresses;
     }
 

--- a/greenmail-junit5/src/test/java/com/icegreen/greenmail/junit5/IdenticalRecipientsTests.java
+++ b/greenmail-junit5/src/test/java/com/icegreen/greenmail/junit5/IdenticalRecipientsTests.java
@@ -1,0 +1,159 @@
+package com.icegreen.greenmail.junit5;
+
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static com.icegreen.greenmail.util.GreenMailUtil.getSession;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for sending emails with identical recipients.
+ * <p>
+ * This class contains tests to verify the behavior of sending emails with identical recipients in the TO, CC, and BCC
+ * fields. It ensures that the email server handles these cases correctly and that only one email is received by the
+ * recipient.
+ */
+public class IdenticalRecipientsTests {
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP)
+        .withConfiguration(GreenMailConfiguration.aConfig()
+            .withUser("test@localhost.com", "login-id", "password"));
+
+    /**
+     * Tests sending an email to one destination with multiple of the same BCC recipients and verifies the received
+     * message including only one email is received.
+     *
+     * @throws MessagingException If there is an error in message creation or sending.
+     */
+    @Test
+    @DisplayName("Send test to with identical recipients with one CC")
+    public void testSendingEmailWithOneCC() throws MessagingException, IOException {
+        Session session = getSession(ServerSetupTest.SMTP);
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSentDate(new Date());
+        mimeMessage.setSubject("Subject");
+        mimeMessage.setText("Body");
+        mimeMessage.setFrom("test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.TO, "test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.CC, "test@localhost.com");
+
+        GreenMailUtil.sendMimeMessage(mimeMessage, "login-id", "password");
+
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+
+        MimeMessage message = messages[0];
+        assertEquals("Subject", message.getSubject());
+        assertEquals("Body", message.getContent());
+
+        assertEquals(1, message.getRecipients(Message.RecipientType.TO).length);
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.TO)[0].toString());
+
+        assertEquals(1, message.getRecipients(Message.RecipientType.CC).length);
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.CC)[0].toString());
+    }
+
+    /**
+     * Tests sending an email to one destination with multiple of the same CC recipients and verifies the received
+     * message including only one email is received.
+     *
+     * @throws MessagingException If there is an error in message creation or sending.
+     */
+    @Test
+    @DisplayName("Send test to with identical recipients with multiple CCs")
+    public void testReceivingEmailsWithMultipleCCs() throws MessagingException, IOException {
+        Session session = getSession(ServerSetupTest.SMTP);
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSentDate(new Date());
+        mimeMessage.setSubject("Subject");
+        mimeMessage.setText("Body");
+        mimeMessage.setFrom("test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.TO, "test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.CC,
+            "test@localhost.com,test@localhost.com,test@localhost.com"
+        );
+
+        GreenMailUtil.sendMimeMessage(mimeMessage, "login-id", "password");
+
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+
+        MimeMessage message = messages[0];
+        assertEquals("Subject", message.getSubject());
+        assertEquals("Body", message.getContent());
+
+        assertEquals(1, message.getRecipients(Message.RecipientType.TO).length);
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.TO)[0].toString());
+
+        assertEquals(3, message.getRecipients(Message.RecipientType.CC).length);
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.CC)[0].toString());
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.CC)[1].toString());
+        assertEquals("test@localhost.com", message.getRecipients(Message.RecipientType.CC)[2].toString());
+    }
+
+    /**
+     * Tests sending an email to one destination with one of the same BCC recipients and verifies the received
+     * message including only one email is received.
+     *
+     * @throws MessagingException If there is an error in message creation or sending.
+     */
+    @Test
+    @DisplayName("Send test to identical recipients with one BCC")
+    public void testReceivingEmailsWithOneBCC() throws MessagingException {
+        Session session = getSession(ServerSetupTest.SMTP);
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSentDate(new Date());
+        mimeMessage.setSubject("Subject");
+        mimeMessage.setText("Body");
+        mimeMessage.setFrom("test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.TO, "test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.BCC, "test@localhost.com");
+
+        GreenMailUtil.sendMimeMessage(mimeMessage, "login-id", "password");
+
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+    }
+
+    /**
+     * Tests sending an email to one destination with multiple of the same BCC recipients and verifies the received
+     * message including only one email is received.
+     *
+     * @throws MessagingException If there is an error in message creation or sending.
+     */
+    @Test
+    @DisplayName("Send test to identical recipients with multiple BCCs")
+    public void testReceivingEmailsWithMultipleBCC() throws MessagingException {
+        Session session = getSession(ServerSetupTest.SMTP);
+
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSentDate(new Date());
+        mimeMessage.setSubject("Subject");
+        mimeMessage.setText("Body");
+        mimeMessage.setFrom("test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.TO, "test@localhost.com");
+        mimeMessage.setRecipients(Message.RecipientType.BCC, "test@localhost.com,test@localhost.com,test@localhost.com");
+
+        GreenMailUtil.sendMimeMessage(mimeMessage, "login-id", "password");
+
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+    }
+}
+


### PR DESCRIPTION
This pull request addresses #856, which was introduced due to duplicate `MimeMessages` showing up when using the `getReceivedMessages()` method when CCs and BCCs are used with the same email destinations.

I originally noticed this when writing various tests to check that CC and BCC properties including multiple destinations were being set correctly in a project I am working on.  

### Steps to Reproduce

In the method `createTextEmail` in the class `GreenMailUtil`, add any number of CCs or BCCs, and many of the existing tests will fail (a lot check only one message is received at some point).

Ex:
```Java
mimeMessage.setRecipients(Message.RecipientType.CC, to);
mimeMessage.setRecipients(Message.RecipientType.BCC, to);
```

### Changes
- Switching from List implementation to Set implementation for `MailAddress` in `MovingMessage` to address recipient duplication.  Without this, all receipients, even if the same in any of the CC, BCC, or TO fields would each receive a new `MimeMessage`.  
- Added equality checks to `MailAddress` to permit usage in Sets and in Streams by overriding the `equals` and `hashCode` methods.
- Added tests to confirm duplicate `MimeMessages` are not received when adding the same destination in CC and BCC fields. 