### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on:
   push:
     branches: [master,releases/2.0.x,releases/1.6.x]


### PR DESCRIPTION
Potential fix for [https://github.com/greenmail-mail-test/greenmail/security/code-scanning/3](https://github.com/greenmail-mail-test/greenmail/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily involves checking out the code and building it with Maven, which typically requires only `contents: read` permissions. If additional permissions are needed in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
