### PR TITLE
Fix FETCH response envelope address list formatting

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -365,10 +365,6 @@ public class SimpleMessageAttributes
             StringBuilder buf = new StringBuilder();
             InternetAddress[] netAddrs = InternetAddress.parseHeader(address, false);
             for (InternetAddress netAddr : netAddrs) {
-                if (buf.length() > 0) {
-                    buf.append(SP);
-                }
-
                 buf.append(LB);
 
                 String personal = netAddr.getPersonal();


### PR DESCRIPTION
Addresses in an FETCH response address lists (used for cc, bcc, etc.) should not have spaces in between them. See [RFC3501 formal syntax, `env-cc`](https://datatracker.ietf.org/doc/html/rfc3501#section-9).

Let me know if this code exists for a different reason, or if this behavior is present in other IMAP servers (although I did test one production email server and it sent the address lists without spaces). This was just a minor issue I found while testing an IMAP parser that I wrote. Thanks maintaining for this great project!