### PR TITLE
add explicit dependency management for the Jackson core modules in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,6 +548,22 @@
         <artifactId>bcpkix-jdk18on</artifactId>
         <version>1.81</version>
       </dependency>
+      <!-- Fix for CVE 2025-52999 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.15.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.15.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.15.0</version>
+      </dependency>      
     </dependencies>
   </dependencyManagement>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -550,20 +550,12 @@
       </dependency>
       <!-- Fix for CVE 2025-52999 -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.15.0</version>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.19.2</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.15.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.15.0</version>
-      </dependency>      
     </dependencies>
   </dependencyManagement>
   <profiles>


### PR DESCRIPTION

When scanning the docker image this CVE is detected due to the transitive dependency created by jersey-media-json-jackson. com.fasterxml.jackson.core should be >= v2.15 to resolve CVE 2025-52999