### PR TITLE
Parse -Dgreenmail.users password in core to allow for ':' and '@'

### DIFF
--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
@@ -19,6 +19,17 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
     }
 
     @Test
+    public void testBuildForSingleUserWithColonInPassword() {
+        Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS,
+                "foo1:pw:rd@1@bar.com");
+        GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getUsersToCreate()).hasSize(1);
+        assertThat(config.getUsersToCreate().get(0)).isEqualTo(new UserBean("foo1@bar.com", "foo1", "pw:rd@1"));
+    }
+
+    @Test
     public void testBuildForListOfUsers() {
         Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_USERS,
                 "foo1:pwd1@bar.com,foo2:pwd2,foo3:pwd3@bar3.com");


### PR DESCRIPTION
As mentioned in #915

Parsing of the users string already works like this in the greenmail-spring version:
https://github.com/greenmail-mail-test/greenmail/blob/308617a392e10434d7a53f067423e48c5472d1e5/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java#L113-L128

So therefore I just adapted that in core and added a Test case for it with userstring `foo1:pw:rd1@bar.com` 