### PR TITLE
fix out-of-bounds partial fetch when offset exceeds content length

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
@@ -557,16 +557,17 @@ class FetchCommand extends SelectedStateCommand implements UidEnabledCommand {
         int size;
 
         int computeLength(final int contentSize) {
+            final int effectiveStart = computeStart(contentSize);
             if (size > 0) {
-                return Math.min(size, contentSize - start); // Only up to max available bytes
+                return Math.min(size, contentSize - effectiveStart); // Only up to max available bytes
             } else {
-                // First len bytes
-                return contentSize;
+                // Remaining bytes starting at the origin octet
+                return contentSize - effectiveStart;
             }
         }
 
         int computeStart(final int contentSize) {
-            return Math.min(start, contentSize);
+            return Math.min(Math.max(start, 0), contentSize);
         }
 
         public static Partial as(int start, int size) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -158,6 +158,28 @@ public class ImapProtocolTest {
     }
 
     @Test
+    public void testFetchPartialOffsetBeyondContent() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_ONLY);
+
+            // A partial origin octet at or beyond the content length must return an
+            // empty result instead of failing, see https://tools.ietf.org/html/rfc3501#section-6.4.5
+            Response[] ret = (Response[]) folder.doCommand(
+                protocol -> protocol.command("UID FETCH 1 (BODY[HEADER]<100000.30>)", null));
+            assertThat(ret[ret.length - 1].isOK()).isTrue();
+
+            FetchResponse fetchResponse = (FetchResponse) ret[0];
+            BODY body = fetchResponse.getItem(BODY.class);
+            assertThat(body.isHeader()).isTrue();
+            assertThat(body.getByteArray().getCount()).isEqualTo(0);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
     public void testSearchSequenceSet() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {


### PR DESCRIPTION
A BODY[...]<origin.size> fetch whose origin lands at or past the end of the section currently fails with an out-of-range error instead of returning an empty result.
Partial.computeLength used the raw origin and went negative while computeStart already clamped it; deriving the length from the clamped origin keeps the slice in range.