### PR TITLE
byte-stuff dot lines in POP3 TOP response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/TopCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/TopCommand.java
@@ -65,7 +65,7 @@ public class TopCommand
             throws IOException {
         String line;
         while ((line = in.readLine()) != null) {
-            conn.println(line);
+            writeLine(conn, line);
             if (line.isEmpty())
                 break;
         }
@@ -77,8 +77,18 @@ public class TopCommand
         int count = 0;
         String line;
         while ((line = in.readLine()) != null && count < numLines) {
-            conn.println(line);
+            writeLine(conn, line);
             count++;
+        }
+    }
+
+    // RFC 1939 §3: any line of a multi-line response that begins with the
+    // termination octet must be byte-stuffed with an extra '.'.
+    private static void writeLine(Pop3Connection conn, String line) {
+        if (line.startsWith(".")) {
+            conn.println("." + line);
+        } else {
+            conn.println(line);
         }
     }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
@@ -3,6 +3,8 @@ package com.icegreen.greenmail.pop3;
 import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.pop3.commands.AuthCommand;
 import com.icegreen.greenmail.user.UserException;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -13,6 +15,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +24,8 @@ public class POP3CommandTest {
     private static final String CRLF = "\r\n";
 
     @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.POP3);
+    public final GreenMailRule greenMail = new GreenMailRule(
+        new ServerSetup[]{ServerSetupTest.SMTP, ServerSetupTest.POP3});
 
     private int port;
     private String hostAddress;
@@ -103,6 +108,36 @@ public class POP3CommandTest {
             assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
             printStream.print("USER blar@blar.com" + CRLF);
             assertThat(reader.readLine()).isNotEqualTo("+OK");
+        });
+    }
+
+    @Test
+    public void topByteStuffsLinesStartingWithDot() throws IOException {
+        String to = "test@localhost";
+        greenMail.setUser(to, "pwd");
+        // Body with a bare "." line and a ".dot" line. RetrCommand already
+        // byte-stuffs these per RFC 1939 §3; TOP must do the same or the
+        // multi-line response terminates early at the first "." line.
+        GreenMailUtil.sendTextEmailTest(to, "from@localhost", "s",
+            "first\r\n.\r\n.dot\r\nlast");
+        greenMail.waitForIncomingEmail(5000, 1);
+
+        withConnection((printStream, reader) -> {
+            assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
+            printStream.print("USER " + to + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+            printStream.print("PASS pwd" + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+            printStream.print("TOP 1 99" + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null && !".".equals(line)) {
+                lines.add(line);
+            }
+            assertThat(line).isEqualTo(".");
+            assertThat(lines).contains("..", "..dot", "last");
         });
     }
 


### PR DESCRIPTION
TopCommand passes message lines straight to conn.println, so a body line that is just "." terminates the multi-line response early — the client sees "+OK", the headers and the leading body lines, then thinks the response ended at the first "." line.

RetrCommand already applies RFC 1939 §3 byte-stuffing (`"\\r\\n\\." -> "\\r\\n.."`); TOP needs the same. Reproduced by sending a mail whose body contains "first\\r\\n.\\r\\n.dot\\r\\nlast" and issuing `TOP 1 99`: without the patch the response stops at the first "." and "..dot" / "last" never make it to the client. Test added in POP3CommandTest covers the case.