### PR TITLE
escape quoted header fields in FETCH BODYSTRUCTURE

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -430,19 +430,19 @@ public class SimpleMessageAttributes
         if (contentID == null) {
             buf.append(NIL);
         } else {
-            buf.append(Q).append(contentID).append(Q);
+            buf.append(Q).append(escapeHeader(contentID)).append(Q);
         }
         buf.append(SP);
         if (contentDesc == null) {
             buf.append(NIL);
         } else {
-            buf.append(Q).append(contentDesc).append(Q);
+            buf.append(Q).append(escapeHeader(contentDesc)).append(Q);
         }
         buf.append(SP);
         if (contentEncoding == null) {
             buf.append(NIL);
         } else {
-            buf.append(Q).append(contentEncoding).append(Q);
+            buf.append(Q).append(escapeHeader(contentEncoding)).append(Q);
         }
         buf.append(SP);
         buf.append(size);
@@ -512,7 +512,7 @@ public class SimpleMessageAttributes
                 //4. body id -------
                 buf.append(' ');
                 if (null != contentID ) {
-                    buf.append(Q).append(contentID).append(Q);
+                    buf.append(Q).append(escapeHeader(contentID)).append(Q);
                 } else {
                     buf.append(NIL);
                 }
@@ -520,7 +520,7 @@ public class SimpleMessageAttributes
                 buf.append(' ');
                 if (null != contentDesc) {
                     buf.append('\"');
-                    buf.append(contentDesc);
+                    buf.append(escapeHeader(contentDesc));
                     buf.append('\"');
                 } else {
                     buf.append(NIL);
@@ -529,7 +529,7 @@ public class SimpleMessageAttributes
                 buf.append(' ');
                 if (null != contentEncoding) {
                     buf.append('\"');
-                    buf.append(contentEncoding);
+                    buf.append(escapeHeader(contentEncoding));
                     buf.append('\"');
                 } else {
                     buf.append(NIL);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/SimpleMessageAttributesEscapeTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/SimpleMessageAttributesEscapeTest.java
@@ -1,0 +1,46 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleMessageAttributesEscapeTest {
+
+    private SimpleMessageAttributes attributesFor(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+                new ByteArrayInputStream(raw.getBytes(StandardCharsets.US_ASCII)));
+        return new SimpleMessageAttributes(msg, new Date());
+    }
+
+    @Test
+    public void textPartBodyStructureEscapesContentDescription() throws Exception {
+        String raw = "From: a@b.com\r\n" +
+                "Subject: x\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "Content-Description: he\"llo\\world\r\n" +
+                "\r\n" +
+                "body\r\n";
+        String bs = attributesFor(raw).getBodyStructure(false);
+        assertThat(bs).contains("\"he\\\"llo\\\\world\"");
+    }
+
+    @Test
+    public void nonTextPartBodyStructureEscapesContentDescription() throws Exception {
+        String raw = "From: a@b.com\r\n" +
+                "Subject: x\r\n" +
+                "Content-Type: application/octet-stream\r\n" +
+                "Content-Description: ev\"il\r\n" +
+                "\r\n" +
+                "body\r\n";
+        String bs = attributesFor(raw).getBodyStructure(false);
+        assertThat(bs).contains("\"ev\\\"il\"");
+    }
+}


### PR DESCRIPTION
parseEnvelope escapes the subject and message-id via escapeHeader, but parseBodyFields/parseBodyStructure in SimpleMessageAttributes.java emit Content-ID, Content-Description and Content-Transfer-Encoding as IMAP quoted strings unescaped, so a sender-supplied header like `Content-Description: he"llo` makes FETCH BODYSTRUCTURE return `"he"llo"` and corrupts the response the client parses. Route those three fields through the existing escapeHeader.