### PR TITLE
escape content-disposition type in BODYSTRUCTURE response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -673,10 +673,10 @@ public class SimpleMessageAttributes
             // https://tools.ietf.org/html/rfc3501#section-9 body-fld-dsp
             StringBuilder ret = new StringBuilder();
             if (null == params) {
-                ret.append(Q).append(value).append(Q);
+                ret.append(Q).append(escapeHeader(value)).append(Q);
             } else {
                 ret.append(LB);
-                ret.append(Q).append(value).append(Q + SP);
+                ret.append(Q).append(escapeHeader(value)).append(Q + SP);
                 if (params.isEmpty()) {
                     ret.append(NIL);
                 } else {
@@ -706,7 +706,7 @@ public class SimpleMessageAttributes
         }
     }
 
-    private String escapeHeader(final String text) {
+    private static String escapeHeader(final String text) {
         return MimeUtility.unfold(text).replace("\\", "\\\\").replace("\"", "\\\"");
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/ContentDispositionEscapeTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/ContentDispositionEscapeTest.java
@@ -1,0 +1,27 @@
+package com.icegreen.greenmail.store;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContentDispositionEscapeTest {
+    @Test
+    public void bodyStructureEscapesDispositionType() throws Exception {
+        String raw = "Content-Type: application/octet-stream\r\n" +
+                "Content-Disposition: attachment\"injected\r\n" +
+                "Content-Transfer-Encoding: base64\r\n" +
+                "\r\n" +
+                "AAEC\r\n";
+        MimeMessage msg = GreenMailUtil.newMimeMessage(raw);
+        SimpleMessageAttributes attrs = new SimpleMessageAttributes(msg, new Date());
+
+        String bodyStructure = attrs.getBodyStructure(true);
+
+        // The sender-controlled disposition type must not break the IMAP quoted string.
+        assertThat(bodyStructure).contains("attachment\\\"injected");
+    }
+}


### PR DESCRIPTION
The body-fld-dsp disposition type comes straight from a sender's Content-Disposition header and Header.toString writes it as a quoted string without escaping, unlike the body-fld-id/desc/enc fields. A header like `Content-Disposition: attachment"x` closes the quoted string early and injects tokens into the FETCH BODYSTRUCTURE response the recipient's IMAP client parses. Route the value through the existing escapeHeader helper (now static so the nested Header class can reuse it).