### PR TITLE
escape personal name in FETCH ENVELOPE response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -371,10 +371,10 @@ public class SimpleMessageAttributes
                 if (personal != null && (!personal.isEmpty())) {
                     try {
                         String encodedPersonal = MimeUtility.encodeWord(personal, StandardCharsets.UTF_8.name(),null);
-                        buf.append(Q).append(encodedPersonal).append(Q);
+                        buf.append(Q).append(escapeHeader(encodedPersonal)).append(Q);
                     } catch (UnsupportedEncodingException e) {
                         log.warn("Failed to encode personal address part {} for {}, using personal 'as is'", personal, netAddr);
-                        buf.append(Q).append(personal).append(Q);
+                        buf.append(Q).append(escapeHeader(personal)).append(Q);
                     }
                 } else {
                     buf.append(NIL);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeAddressEscapeTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeAddressEscapeTest.java
@@ -1,0 +1,27 @@
+package com.icegreen.greenmail.store;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvelopeAddressEscapeTest {
+    @Test
+    public void envelopeEscapesPersonalName() throws Exception {
+        String raw = "Subject: hi\r\n" +
+                "From: \"foo\\\"bar\" <a@b.com>\r\n" +
+                "\r\n" +
+                "body\r\n";
+        MimeMessage msg = GreenMailUtil.newMimeMessage(raw);
+        SimpleMessageAttributes attrs = new SimpleMessageAttributes(msg, new Date());
+
+        String envelope = attrs.getEnvelope();
+
+        // The sender-controlled personal name must not break the IMAP quoted string.
+        assertThat(envelope).contains("foo\\\"bar");
+        assertThat(envelope).doesNotContain("\"foo\"bar\"");
+    }
+}


### PR DESCRIPTION
The address personal name in a FETCH ENVELOPE comes straight from the sender's From/To/Cc headers, but parseAddress wraps it in an IMAP quoted string without escaping. MimeUtility.encodeWord leaves a plain ASCII double-quote untouched, so a personal name like foo"bar terminates the quoted string early and lets the sender inject extra address-structure tokens the recipient's client parses. Route it through the existing escapeHeader helper, as subject and message-id already are.