### PR TITLE
escape body type and subtype in FETCH BODYSTRUCTURE

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -476,8 +476,8 @@ public class SimpleMessageAttributes
             StringBuilder buf = new StringBuilder();
             buf.append(LB);
             if (primaryType.equalsIgnoreCase("TEXT")) {
-                buf.append('"').append(primaryType).append("\" \"")
-                    .append(secondaryType).append("\" ")
+                buf.append('"').append(escapeHeader(primaryType)).append("\" \"")
+                    .append(escapeHeader(secondaryType)).append("\" ")
                     .append(fields)
                     .append(' ')
                     .append(lineCount);
@@ -496,15 +496,15 @@ public class SimpleMessageAttributes
 //                    setupLogger(parts[i]); // reset transient getLogger()
                     buf.append(part.getBodyStructure(includeExtension));
                 }
-                buf.append(SP + Q).append(secondaryType).append(Q);
+                buf.append(SP + Q).append(escapeHeader(secondaryType)).append(Q);
             } else {
                 //1. primary type -------
                 buf.append('\"');
-                buf.append(primaryType.toUpperCase());
+                buf.append(escapeHeader(primaryType.toUpperCase()));
                 buf.append('\"');
                 //2. sec type -------
                 buf.append(" \"");
-                buf.append(secondaryType.toUpperCase());
+                buf.append(escapeHeader(secondaryType.toUpperCase()));
                 buf.append('\"');
                 //3. params -------
                 buf.append(' ');

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureTypeQuotingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureTypeQuotingTest.java
@@ -1,0 +1,44 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The body type and subtype emitted in a FETCH BODYSTRUCTURE response originate
+ * from the sender's Content-Type header. They must be escaped before being
+ * wrapped in IMAP quoted strings, otherwise a double-quote terminates the
+ * quoted string early and injects tokens into the response.
+ */
+public class BodyStructureTypeQuotingTest {
+
+    private String bodyStructure(String contentType) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        String raw = "From: a@b.com\r\nTo: c@d.com\r\nSubject: x\r\n"
+            + "Content-Type: " + contentType + "\r\n\r\nbody\r\n";
+        MimeMessage message = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(message, new Date()).getBodyStructure(true);
+    }
+
+    @Test
+    public void escapesQuoteInTextSubtype() throws Exception {
+        assertThat(bodyStructure("text/pl\"ain"))
+            .contains("\"pl\\\"ain\"")
+            .doesNotContain("\"pl\"ain\"");
+    }
+
+    @Test
+    public void escapesQuoteInTypeAndSubtype() throws Exception {
+        assertThat(bodyStructure("appli\"cation/oct\"et"))
+            .contains("\"APPLI\\\"CATION\"")
+            .contains("\"OCT\\\"ET\"");
+    }
+}


### PR DESCRIPTION
The body type and subtype in a FETCH BODYSTRUCTURE come from the sender's Content-Type header, but parseBodyStructure wraps them in IMAP quoted strings without escaping. A Content-Type like `text/pl"ain` makes the response `("text" "pl"ain" ...)`, closing the quoted string early and injecting tokens the recipient's client parses. Route both through the existing escapeHeader helper at each emission site, as subject and message-id already are.