### PR TITLE
escape mime parameters in BODYSTRUCTURE response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -665,7 +665,13 @@ public class SimpleMessageAttributes
         }
 
         private String strip(String s) {
-            return s.trim().replaceAll("\\\"", "");
+            s = s.trim();
+            // Unwrap a single surrounding pair of double quotes from the raw parameter.
+            if (s.length() >= 2 && s.charAt(0) == '"' && s.charAt(s.length() - 1) == '"') {
+                s = s.substring(1, s.length() - 1);
+            }
+            // Escape quoted-specials so the value can't break out of the IMAP quoted string.
+            return s.replace("\\", "\\\\").replace("\"", "\\\"");
         }
 
         @Override

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureParameterQuotingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureParameterQuotingTest.java
@@ -1,0 +1,47 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BodyStructureParameterQuotingTest {
+
+    private String bodyStructure(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date()).getBodyStructure(true);
+    }
+
+    @Test
+    public void dispositionParameterTrailingBackslashIsEscaped() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain\r\n"
+            + "Content-Disposition: attachment; filename=\"evil\\\"\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"filename\" \"evil\\\\\"");
+    }
+
+    @Test
+    public void contentTypeParameterQuoteIsEscaped() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain; name=\"ev\\\"il\"\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"name\" \"ev\\\\\\\"il\"");
+    }
+
+    @Test
+    public void plainParameterIsUnchanged() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain; charset=\"utf-8\"\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"charset\" \"utf-8\"");
+    }
+}


### PR DESCRIPTION
Noticed the Content-Type and Content-Disposition parameter strings in BODYSTRUCTURE are built by strip(), which removes double-quotes but leaves backslashes, then wraps the value back in quotes. A sender-set parameter ending in a backslash (filename="x\") emits ("filename" "x\"), so the trailing \" reads as an escaped quote and the client's quoted string never closes. strip now unwraps the surrounding quotes and escapes backslash and double-quote.