### PR TITLE
escape quota root name in QUOTA and QUOTAROOT responses

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaCommand.java
@@ -68,10 +68,24 @@ public class GetQuotaCommand extends AuthenticatedStateCommand {
 
     protected void appendQuotaRootName(Quota quota, StringBuilder buf) {
         String rootName = quota.quotaRoot;
-        if(null == rootName || rootName.isEmpty()) {
-            rootName = "\"\"";
+        if (null == rootName) {
+            rootName = "";
         }
-        buf.append('\"').append(rootName).append('\"');
+        buf.append(quoteName(rootName));
+    }
+
+    /**
+     * Renders a client-supplied quota root / mailbox name as an IMAP quoted string,
+     * escaping the quoted-specials and dropping CR/LF so it cannot terminate the
+     * quoted string early or inject extra response lines.
+     */
+    protected static String quoteName(String name) {
+        String escaped = name
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\r", "")
+            .replace("\n", "");
+        return '"' + escaped + '"';
     }
 }
 

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaRootCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaRootCommand.java
@@ -39,7 +39,7 @@ public class GetQuotaRootCommand extends GetQuotaCommand {
             buf.append(' ');
             appendQuotaRootName(q, buf);
         }
-        response.untaggedResponse("QUOTAROOT "+root);
+        response.untaggedResponse("QUOTAROOT " + quoteName(root));
         for (Quota q : quota) {
             buf = new StringBuilder();
             appendQuota(q, buf);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/QuotaRootNameQuotingTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/QuotaRootNameQuotingTest.java
@@ -1,0 +1,63 @@
+package com.icegreen.greenmail.imap;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuotaRootNameQuotingTest {
+    private static final String CRLF = "\r\n";
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP);
+
+    @Test
+    public void getQuotaRootDoesNotInjectResponseLines() throws IOException {
+        greenMail.setUser("foo@localhost", "pwd");
+
+        String host = greenMail.getImap().getBindTo();
+        int port = greenMail.getImap().getPort();
+        try (Socket socket = new Socket(host, port)) {
+            OutputStream os = socket.getOutputStream();
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+
+            assertThat(reader.readLine()).startsWith("* OK");
+
+            os.write(("a1 LOGIN foo@localhost pwd" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.flush();
+            String line;
+            while ((line = reader.readLine()) != null && !line.startsWith("a1 ")) {
+                // skip
+            }
+            assertThat(line).startsWith("a1 OK");
+
+            // Mailbox name supplied as a non-synchronizing literal carrying a CRLF
+            // ("INBOX\r\nX" == 8 bytes).
+            os.write(("a2 GETQUOTAROOT {8+}" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.write(("INBOX" + CRLF + "X" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.flush();
+
+            List<String> lines = new ArrayList<>();
+            while ((line = reader.readLine()) != null && !line.startsWith("a2 ")) {
+                lines.add(line);
+            }
+
+            // The CRLF carried in the mailbox name must not split the response into
+            // a forged "X" line; the name is emitted as a single quoted token.
+            assertThat(lines).doesNotContain("X");
+            assertThat(lines).containsExactly("* QUOTAROOT \"INBOXX\"");
+        }
+    }
+}


### PR DESCRIPTION
Noticed GETQUOTAROOT echoes the mailbox argument bare (`"QUOTAROOT "+root`) and GETQUOTA wraps the quota root in quotes without escaping it. The name comes from `parser.mailbox`/`astring`, which accepts a `{n}` literal, so a value like `INBOX<CR><LF>X` splits the untagged response and injects a forged line the client parses. Route both names through a small helper that quotes the value, escapes `\` and `"`, and drops CR/LF.