### PR TITLE
reject non-atom characters in imap flag keywords

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
@@ -349,7 +349,7 @@ public class CommandParser {
         return flags;
     }
 
-    public void setFlag(String flagString, Flags flags) {
+    public void setFlag(String flagString, Flags flags) throws ProtocolException {
         if (flagString.equalsIgnoreCase(MessageFlags.ANSWERED)) {
             flags.add(Flags.Flag.ANSWERED);
         } else if (flagString.equalsIgnoreCase(MessageFlags.DELETED)) {
@@ -363,9 +363,24 @@ public class CommandParser {
         } else if (flagString.equalsIgnoreCase(MessageFlags.RECENT)) {
             flags.add(Flags.Flag.RECENT);
         } else {
-            // User flag
-            flags.add(flagString);
+            // User flag (flag-keyword = atom). Keywords are echoed verbatim in
+            // FLAGS/PERMANENTFLAGS/FETCH FLAGS responses, so reject anything that is
+            // not a valid atom before it can break the parenthesized flag list.
+            flags.add(validateKeyword(flagString));
         }
+    }
+
+    private String validateKeyword(String keyword) throws ProtocolException {
+        if (keyword.isEmpty()) {
+            throw new ProtocolException("Invalid flag keyword: empty");
+        }
+        for (int i = 0; i < keyword.length(); i++) {
+            char chr = keyword.charAt(i);
+            if (!isCHAR(chr) || isAtomSpecial(chr) || isQuotedSpecial(chr)) {
+                throw new ProtocolException("Invalid flag keyword: '" + keyword + '\'');
+            }
+        }
+        return keyword;
     }
 
     /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/FlagKeywordValidationTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/FlagKeywordValidationTest.java
@@ -1,0 +1,51 @@
+package com.icegreen.greenmail.imap.commands;
+
+import com.icegreen.greenmail.imap.ImapRequestLineReader;
+import com.icegreen.greenmail.imap.ProtocolException;
+import com.icegreen.greenmail.store.MessageFlags;
+import jakarta.mail.Flags;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class FlagKeywordValidationTest {
+
+    private Flags flagList(String input) throws ProtocolException {
+        ImapRequestLineReader reader = new ImapRequestLineReader(
+                new ByteArrayInputStream(input.getBytes(StandardCharsets.US_ASCII)),
+                new ByteArrayOutputStream());
+        return new CommandParser().flagList(reader);
+    }
+
+    @Test
+    public void acceptsValidKeyword() throws ProtocolException {
+        Flags flags = flagList("(\\Seen foobar)\r\n");
+        assertThat(flags.contains(Flags.Flag.SEEN)).isTrue();
+        assertThat(flags.getUserFlags()).containsExactly("foobar");
+        // Echoed value stays inside the parenthesized flag list.
+        assertThat(MessageFlags.format(flags)).doesNotContain("\"");
+    }
+
+    @Test
+    public void rejectsKeywordWithQuotedSpecial() {
+        assertThatThrownBy(() -> flagList("(\\Seen ab\"cd)\r\n"))
+                .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void rejectsKeywordWithBackslash() {
+        assertThatThrownBy(() -> flagList("(a\\b)\r\n"))
+                .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void rejectsKeywordWithListClose() {
+        assertThatThrownBy(() -> flagList("(foo]bar)\r\n"))
+                .isInstanceOf(ProtocolException.class);
+    }
+}


### PR DESCRIPTION
flagList parses a STORE/APPEND flag list with a NoopCharValidator, so a user keyword may carry any non-whitespace byte. setFlag stores it verbatim and MessageFlags.format echoes it bare inside the parenthesized FLAGS/PERMANENTFLAGS/FETCH FLAGS list, which has no quoted form for an atom; a keyword like ab"cd or foo]bar then breaks the flag list another session sharing the mailbox parses. Validate the keyword in setFlag and reject non-atom characters, the way flagList already rejects malformed arguments.