### PR TITLE
reject CR and LF in IMAP quoted strings

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
@@ -310,6 +310,13 @@ public class CommandParser {
         StringBuilder quoted = new StringBuilder();
         char next = request.nextChar();
         while (next != '"') {
+            // RFC 3501: a quoted string is *QUOTED-CHAR, and QUOTED-CHAR excludes CR and LF.
+            // Clients must use a literal to carry such octets. Accepting them here lets a
+            // quoted argument smuggle line breaks into the value, which later surface as
+            // forged lines in untagged responses that echo the argument.
+            if (isCrOrLf(next)) {
+                throw new ProtocolException("Invalid character in quoted string: CR and LF are not allowed, use a literal instead");
+            }
             if (next == '\\') {
                 request.consume();
                 next = request.nextChar();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
@@ -1,8 +1,14 @@
 package com.icegreen.greenmail.imap.commands;
 
+import com.icegreen.greenmail.imap.ImapRequestLineReader;
+import com.icegreen.greenmail.imap.ProtocolException;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CommandParserTest {
     @Test
@@ -10,5 +16,28 @@ public class CommandParserTest {
         assertThat(CommandParser.isCrOrLf('\n')).isTrue();
         assertThat(CommandParser.isCrOrLf('\r')).isTrue();
         assertThat(CommandParser.isCrOrLf('\t')).isFalse();
+    }
+
+    @Test
+    public void consumeQuotedParsesRegularContent() throws ProtocolException {
+        assertThat(consumeQuoted("\"hello world\"\r\n")).isEqualTo("hello world");
+        assertThat(consumeQuoted("\"a\\\"b\"\r\n")).isEqualTo("a\"b");
+    }
+
+    @Test
+    public void consumeQuotedRejectsEmbeddedCr() {
+        assertThatThrownBy(() -> consumeQuoted("\"a\rb\"\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void consumeQuotedRejectsEmbeddedLf() {
+        assertThatThrownBy(() -> consumeQuoted("\"INBOX\r\n* 9 EXISTS\"\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    private static String consumeQuoted(String line) throws ProtocolException {
+        ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
+        return new CommandParser().consumeQuoted(new ImapRequestLineReader(in, null));
     }
 }


### PR DESCRIPTION
1. consumeQuoted appends every octet up to the closing quote, so CR and LF end up in the parsed value, but RFC 3501 limits a quoted string to QUOTED-CHAR which excludes CR and LF.
2. a quoted argument such as a mailbox name can then carry an embedded CRLF that is echoed back inside double-quotes in LIST/STATUS, forging an untagged response line in the stream the client parses; literals are the intended way to send such octets.
3. reject CR and LF in consumeQuoted with a ProtocolException, matching how other malformed arguments are handled, so every quoted argument is validated at the parser.

Added CommandParserTest cases: a quoted value with an embedded CR or LF now fails, regular quoted strings (including an escaped quote) still parse.