### PR TITLE
strip CR/LF from HELO and return path in DATA trace header

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/DataCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/DataCommand.java
@@ -41,10 +41,15 @@ public class DataCommand extends SmtpCommand {
 
         conn.send("354 Start mail input; end with <CRLF>.<CRLF>");
 
-        String initialContent = "Return-Path: <" + msg.getReturnPath() +
+        // The HELO argument and the MAIL FROM return path are client-supplied and must not
+        // carry CR or LF; otherwise they split this trace header block and inject extra
+        // header lines into the stored message.
+        String returnPath = stripLineBreaks(String.valueOf(msg.getReturnPath()));
+        String heloName = stripLineBreaks(conn.getHeloName());
+        String initialContent = "Return-Path: <" + returnPath +
             ">\r\n" + "Received: from " +
             conn.getClientAddress() + " (HELO " +
-            conn.getHeloName() + "); " +
+            heloName + "); " +
             new java.util.Date() + "\r\n";
 
         try (final InputStream messageIs = conn.dotLimitedInputStream(initialContent.getBytes(StandardCharsets.UTF_8))) {
@@ -66,5 +71,12 @@ public class DataCommand extends SmtpCommand {
         }
 
         state.clearMessage();
+    }
+
+    private static String stripLineBreaks(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\r", "").replace("\n", "");
     }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpReceivedHeaderInjectionTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SmtpReceivedHeaderInjectionTest.java
@@ -1,0 +1,120 @@
+package com.icegreen.greenmail.smtp;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The DATA command prepends a {@code Return-Path}/{@code Received} trace header built from the
+ * client-supplied HELO/EHLO argument and the MAIL FROM return path. Neither value may contain
+ * CR or LF; if it does, the trace header is split and the sender can inject additional header
+ * lines into the stored message that a recipient later retrieves.
+ */
+public class SmtpReceivedHeaderInjectionTest {
+    private GreenMail greenMail;
+
+    @Before
+    public void setup() {
+        greenMail = new GreenMail(ServerSetupTest.SMTP);
+        greenMail.start();
+    }
+
+    @After
+    public void tearDown() {
+        greenMail.stop();
+    }
+
+    @Test
+    public void heloArgumentCanNotInjectHeaderViaBareLineFeed() throws Exception {
+        String host = ServerSetupTest.SMTP.getBindAddress();
+        int port = ServerSetupTest.SMTP.getPort();
+
+        try (Socket socket = new Socket(host, port);
+             OutputStream out = socket.getOutputStream();
+             BufferedReader in = new BufferedReader(
+                 new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
+
+            assertThat(in.readLine()).startsWith("220");
+
+            // A bare LF inside the HELO argument is not a CRLF, so the command reader keeps
+            // reading until the real CRLF; the argument carries the embedded line break.
+            send(out, "HELO injected\nX-Injected: bar\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "MAIL FROM:<sender@localhost>\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "RCPT TO:<to@localhost>\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "DATA\r\n");
+            assertThat(in.readLine()).startsWith("354");
+
+            send(out, "Subject: hi\r\n\r\nbody\r\n.\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "QUIT\r\n");
+        }
+
+        assertThat(greenMail.waitForIncomingEmail(1)).isTrue();
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertThat(messages).hasSize(1);
+        assertThat(messages[0].getHeader("X-Injected")).isNull();
+    }
+
+    @Test
+    public void mailFromReturnPathCanNotInjectHeaderViaEncodedWord() throws Exception {
+        String host = ServerSetupTest.SMTP.getBindAddress();
+        int port = ServerSetupTest.SMTP.getPort();
+
+        // decodeText() decodes the RFC 2047 encoded-word, turning the address into
+        // "a\r\nX-Injected2: bar" before it is written into the Return-Path header.
+        String encodedWord = "=?utf-8?B?YQ0KWC1JbmplY3RlZDI6IGJhcg==?=";
+
+        try (Socket socket = new Socket(host, port);
+             OutputStream out = socket.getOutputStream();
+             BufferedReader in = new BufferedReader(
+                 new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
+
+            assertThat(in.readLine()).startsWith("220");
+
+            send(out, "HELO localhost\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "MAIL FROM:<" + encodedWord + ">\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "RCPT TO:<to@localhost>\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "DATA\r\n");
+            assertThat(in.readLine()).startsWith("354");
+
+            send(out, "Subject: hi\r\n\r\nbody\r\n.\r\n");
+            assertThat(in.readLine()).startsWith("250");
+
+            send(out, "QUIT\r\n");
+        }
+
+        assertThat(greenMail.waitForIncomingEmail(1)).isTrue();
+        MimeMessage[] messages = greenMail.getReceivedMessages();
+        assertThat(messages).hasSize(1);
+        assertThat(messages[0].getHeader("X-Injected2")).isNull();
+    }
+
+    private static void send(OutputStream out, String data) throws Exception {
+        out.write(data.getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+}


### PR DESCRIPTION
1. DataCommand prepends a Return-Path/Received trace header built from the HELO/EHLO argument and the MAIL FROM return path, but neither value is checked for CR or LF.
2. A bare LF in the HELO argument survives command reading (a command line ends only at CRLF), and an RFC 2047 encoded-word in MAIL FROM is decoded by MailAddress into bytes that can contain CR/LF, so a sender splits the trace header block and injects extra header lines into the stored message that a recipient later fetches over IMAP/POP3.
3. Strip CR and LF from both client-supplied values before they are concatenated into the header block.

Added a raw-socket test covering the bare-LF HELO path and the encoded-word MAIL FROM path; it fails before the change (an injected X-Injected header is stored) and passes after.