### PR TITLE
drop cr/lf in escapeHeader to stop FETCH response line injection

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -717,7 +717,14 @@ public class SimpleMessageAttributes
     }
 
     private static String escapeHeader(final String text) {
-        return MimeUtility.unfold(text).replace("\\", "\\\\").replace("\"", "\\\"");
+        // RFC 2047 encoded-words are decoded before a header value reaches here (e.g. an address
+        // personal name via InternetAddress.getPersonal()), so the value can contain CR or LF.
+        // An IMAP quoted string (RFC 3501 QUOTED-CHAR) cannot carry CR or LF and there is no
+        // escape for them, so drop them before escaping the quoted-specials. Otherwise a sender
+        // injects forged untagged response lines into the FETCH stream the client parses.
+        return MimeUtility.unfold(text)
+                .replace("\r", "").replace("\n", "")
+                .replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeHeaderLineInjectionTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeHeaderLineInjectionTest.java
@@ -1,0 +1,29 @@
+package com.icegreen.greenmail.store;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvelopeHeaderLineInjectionTest {
+    @Test
+    public void envelopeDropsCrLfFromDecodedPersonalName() throws Exception {
+        // The personal name is an RFC 2047 encoded-word that decodes to bytes containing CRLF.
+        // getPersonal() returns "A\r\n* 9 EXISTS\r\n"; encodeWord leaves it unchanged (ASCII).
+        String raw = "Subject: hi\r\n" +
+                "From: =?UTF-8?Q?A=0D=0A=2A_9_EXISTS=0D=0A?= <a@b.com>\r\n" +
+                "\r\n" +
+                "body\r\n";
+        MimeMessage msg = GreenMailUtil.newMimeMessage(raw);
+        SimpleMessageAttributes attrs = new SimpleMessageAttributes(msg, new Date());
+
+        String envelope = attrs.getEnvelope();
+
+        // A decoded personal name must not be able to forge a response line in the FETCH stream.
+        assertThat(envelope).doesNotContain("\r").doesNotContain("\n");
+        assertThat(envelope).contains("A* 9 EXISTS");
+    }
+}


### PR DESCRIPTION
Repro: send a message whose From personal name is an RFC 2047 encoded-word that decodes to bytes containing CRLF (`=?UTF-8?Q?A=0D=0A=2A_9_EXISTS=0D=0A?= <a@b.com>`), then FETCH ENVELOPE.
Cause: getPersonal() returns the decoded name and MimeUtility.encodeWord leaves the CR/LF untouched because they are ASCII, while escapeHeader only escapes backslash and double-quote, so the raw CRLF lands inside the quoted string and forges an untagged `* 9 EXISTS` line in the response stream the client parses.
Fix: drop CR and LF in escapeHeader before escaping the quoted-specials, so no decoded header value routed through it can break the IMAP response framing. An IMAP quoted string cannot carry CR or LF and there is no escape for them, so the value is fixed at the shared sink rather than per field.