### PR TITLE
reject CR and LF in decoded SASL auth credentials

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslMessage.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslMessage.java
@@ -43,11 +43,23 @@ public class SaslMessage {
      * @param message the SASL message
      */
     public static SaslMessage parse(String message) {
+        // The decoded authzid/authcid/passwd are echoed back verbatim in line-oriented
+        // POP3/SMTP error responses (e.g. the POP3 "-ERR Authentication failed: User <...>"
+        // line), so a field carrying CR or LF would forge additional response lines. The
+        // base64 transport lets such octets through even though the command line itself is
+        // CRLF-terminated, so reject them at the parser.
+        if (containsLineBreak(message)) {
+            throw new IllegalArgumentException("Invalid SASL message: CR and LF are not allowed");
+        }
         String[] parts = message.split("\u0000");
         if (parts.length != 3) {
             throw new IllegalArgumentException(
                     "Expected authorization-id\\0authentication-id\\0passwd but got only " + parts.length + " parts : " + message);
         }
         return new SaslMessage(parts[0], parts[1], parts[2]);
+    }
+
+    private static boolean containsLineBreak(String value) {
+        return value.indexOf((char) 13) >= 0 || value.indexOf((char) 10) >= 0;
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslXoauth2Message.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslXoauth2Message.java
@@ -63,6 +63,12 @@ public class SaslXoauth2Message {
      */
     public static SaslXoauth2Message parse(String message) {
         try {
+            // The decoded username is echoed back verbatim in line-oriented auth-failure
+            // responses (POP3 "-ERR ... User <...>", IMAP tagged NO), so a CR or LF smuggled
+            // in through the base64 transport would forge additional response lines.
+            if (containsLineBreak(message)) {
+                throw new IllegalArgumentException("CR and LF are not allowed");
+            }
             String[] parts = message.split("\\u0001");
             if (parts.length > 2 || !parts[0].startsWith("user=") || !parts[1].startsWith("auth=Bearer ")) {
                 throw new IllegalArgumentException("Invalid authentication string format");
@@ -72,6 +78,10 @@ public class SaslXoauth2Message {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid Base64 or malformed input: " + e.getMessage());
         }
+    }
+
+    private static boolean containsLineBreak(String value) {
+        return value.indexOf((char) 13) >= 0 || value.indexOf((char) 10) >= 0;
     }
 
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,6 +111,47 @@ public class POP3CommandTest {
             printStream.print("USER blar@blar.com" + CRLF);
             assertThat(reader.readLine()).isNotEqualTo("+OK");
         });
+    }
+
+    @Test
+    public void authPlainRejectsCrlfInUsername() throws IOException {
+        // The AUTH initial-response is base64 decoded, so the decoded SASL fields can carry
+        // bytes that the line-oriented POP3 reader would otherwise strip. A username (authcid)
+        // with an embedded CRLF splits the "-ERR Authentication failed: User <...>" error into
+        // several response lines and lets an attacker forge a "+OK" status line.
+        String nul = String.valueOf((char) 0);
+        String crlf = "" + (char) 13 + (char) 10;
+        String malicious = base64(nul + "nouser" + crlf + "+OK injected" + nul + "p");
+        withConnection((printStream, reader) -> {
+            assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
+
+            printStream.print("AUTH PLAIN " + malicious + CRLF);
+            assertThat(reader.readLine()).startsWith("-ERR");
+
+            // The next line read must be the reply to the following command, not an injected line.
+            printStream.print("AUTH FOO" + CRLF);
+            assertThat(reader.readLine()).startsWith("-ERR Required syntax: AUTH mechanism <FOO>");
+        });
+    }
+
+    @Test
+    public void authXoauth2RejectsCrlfInUsername() throws IOException {
+        String ctrlA = String.valueOf((char) 1);
+        String crlf = "" + (char) 13 + (char) 10;
+        String malicious = base64("user=nouser" + crlf + "+OK injected" + ctrlA + "auth=Bearer t" + ctrlA + ctrlA);
+        withConnection((printStream, reader) -> {
+            assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
+
+            printStream.print("AUTH XOAUTH2 " + malicious + CRLF);
+            assertThat(reader.readLine()).startsWith("-ERR");
+
+            printStream.print("AUTH FOO" + CRLF);
+            assertThat(reader.readLine()).startsWith("-ERR Required syntax: AUTH mechanism <FOO>");
+        });
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslMessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslMessageTest.java
@@ -4,6 +4,7 @@ package com.icegreen.greenmail.util;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SaslMessageTest {
     @Test
@@ -20,5 +21,13 @@ public class SaslMessageTest {
         assertThat(saslMessage.getAuthzid()).isEmpty();
         assertThat(saslMessage.getAuthcid()).isEqualTo("authcid");
         assertThat(saslMessage.getPasswd()).isEqualTo("passwd");
+    }
+
+    @Test
+    public void testParseRejectsCrlf() {
+        String nul = String.valueOf((char) 0);
+        String crlf = "" + (char) 13 + (char) 10;
+        assertThatThrownBy(() -> SaslMessage.parse(nul + "auth" + crlf + "cid" + nul + "passwd"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslXoauth2MessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslXoauth2MessageTest.java
@@ -24,4 +24,13 @@ public class SaslXoauth2MessageTest {
     public void testInvalidBase64Input() {
         assertThrows(IllegalArgumentException.class, () -> SaslXoauth2Message.parseBase64Encoded("invalid_base64_string"));
     }
+
+    @Test
+    public void testParseRejectsCrlfInUsername() {
+        String ctrlA = String.valueOf((char) 1);
+        String crlf = "" + (char) 13 + (char) 10;
+        String rawInput = "user=victim" + crlf + "+OK injected" + ctrlA + "auth=Bearer t" + ctrlA + ctrlA;
+        String encoded = Base64.getEncoder().encodeToString(rawInput.getBytes());
+        assertThrows(IllegalArgumentException.class, () -> SaslXoauth2Message.parseBase64Encoded(encoded));
+    }
 }


### PR DESCRIPTION
Repro: against the POP3 port, `AUTH PLAIN <base64>` whose decoded SASL authcid is `nouser` + CRLF + `+OK injected` makes the server answer with three lines, the middle one a forged `+OK injected` status line. `AUTH XOAUTH2` reaches the same error path, and IMAP `AUTHENTICATE XOAUTH2` reflects the same username in its tagged `NO`.

Cause: the AUTH initial-response is base64 decoded, so the SASL fields can carry CR/LF that the CRLF-terminated command reader never sees. `SaslMessage.parse` and `SaslXoauth2Message.parse` pass them straight on to the single-line `-ERR ... User <...> doesn't exist` echo built in `Pop3State.getUser`.

Fix: reject CR and LF in the decoded SASL message inside both parsers, the shared helpers used by the POP3/SMTP/IMAP AUTH paths, so the credentials can never split the line-oriented responses that reflect them.

The committed test drives both POP3 vectors over a socket and asserts that the line read after the malicious AUTH is the following command's reply, not an injected line; the SASL unit tests cover the parser rejection directly.
