### PR TITLE
Remove unused import and dead code

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
@@ -1,7 +1,6 @@
 package com.icegreen.greenmail.configuration;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Properties;
 import java.util.function.BinaryOperator;
 import java.util.regex.Matcher;

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
@@ -133,10 +133,7 @@ public class UserManager {
         return true;
     }
 
-    private boolean checkPassword(String expectedPassword, String password) {
-        return (null != expectedPassword && expectedPassword.equals(password))
-                || (null == password && expectedPassword == null);
-    }
+
 
     public void setAuthRequired(boolean auth) {
         authRequired = auth;


### PR DESCRIPTION
Problem
There is an unused import and an unused private method.
Solution
Removed dead code from PropertiesBasedGreenMailConfigurationBuilder and UserManager by deleting the unused java.util.Arrays import and the unused private checkPassword() method.