### PR TITLE
strip cr/lf from imap NO and BAD error response messages

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapResponse.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapResponse.java
@@ -90,7 +90,7 @@ public class ImapResponse implements ImapConstants {
         responseCode(responseCode);
         commandName(command);
         message("failed.");
-        message(reason);
+        message(stripLineBreaks(reason));
         end();
     }
 
@@ -105,7 +105,7 @@ public class ImapResponse implements ImapConstants {
     public void commandError(String message) {
         tag();
         message(BAD);
-        message(message);
+        message(stripLineBreaks(message));
         end();
     }
 
@@ -115,7 +115,7 @@ public class ImapResponse implements ImapConstants {
     public void badResponse(String message) {
         untagged();
         message(BAD);
-        message(message);
+        message(stripLineBreaks(message));
         end();
     }
 
@@ -242,6 +242,27 @@ public class ImapResponse implements ImapConstants {
     private void end() {
         writer.println();
         writer.flush();
+    }
+
+    /**
+     * Removes CR and LF from a free-text response message. NO/BAD responses echo
+     * client-supplied values back (a mailbox name in "No such folder : &lt;name&gt;",
+     * the LOGIN user id, a SEARCH charset), and those values can carry CR/LF when sent
+     * as an IMAP literal. Dropping the line breaks keeps the reason on a single line so
+     * it cannot forge extra response lines in the stream the client parses.
+     */
+    static String stripLineBreaks(String message) {
+        if (message == null || (message.indexOf('\r') < 0 && message.indexOf('\n') < 0)) {
+            return message;
+        }
+        StringBuilder sb = new StringBuilder(message.length());
+        for (int i = 0; i < message.length(); i++) {
+            char c = message.charAt(i);
+            if (c != '\r' && c != '\n') {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     public void permanentFlagsResponse(Flags flags) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ErrorResponseLineInjectionTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ErrorResponseLineInjectionTest.java
@@ -1,0 +1,64 @@
+package com.icegreen.greenmail.imap;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ErrorResponseLineInjectionTest {
+    private static final String CRLF = "\r\n";
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP);
+
+    @Test
+    public void mailboxNameInErrorResponseDoesNotInjectLines() throws IOException {
+        greenMail.setUser("foo@localhost", "pwd");
+
+        String host = greenMail.getImap().getBindTo();
+        int port = greenMail.getImap().getPort();
+        try (Socket socket = new Socket(host, port)) {
+            OutputStream os = socket.getOutputStream();
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+
+            assertThat(reader.readLine()).startsWith("* OK");
+
+            os.write(("a1 LOGIN foo@localhost pwd" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.flush();
+            String line;
+            while ((line = reader.readLine()) != null && !line.startsWith("a1 ")) {
+                // skip
+            }
+            assertThat(line).startsWith("a1 OK");
+
+            // Non-existent mailbox name supplied as a non-synchronizing literal carrying a
+            // CRLF ("INBOX\r\nX" == 8 bytes). DELETE fails and the name is echoed back in
+            // the tagged "NO ... No such folder : <name>" response.
+            os.write(("a2 DELETE {8+}" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.write(("INBOX" + CRLF + "X" + CRLF).getBytes(StandardCharsets.US_ASCII));
+            os.flush();
+
+            List<String> lines = new ArrayList<>();
+            while ((line = reader.readLine()) != null && !line.startsWith("a2 ")) {
+                lines.add(line);
+            }
+
+            // The CRLF carried in the mailbox name must not split the response into a
+            // forged "X" line; the whole reason stays on the single tagged line.
+            assertThat(lines).doesNotContain("X");
+            assertThat(line).startsWith("a2 NO").contains("No such folder : INBOXX");
+        }
+    }
+}


### PR DESCRIPTION
1. IMAP NO/BAD responses echo client-supplied argument values in the reason text: the mailbox name in "No such folder : <name>" (DELETE/RENAME and other CommandTemplate failures), the LOGIN user id in "Invalid login/password for user id <id>", and the SEARCH charset.
2. those arguments can carry raw CR/LF when supplied as an IMAP literal ({n} form). consumeQuoted already rejects CR/LF but a literal does not, so the embedded CRLF splits the single-line response and forges an extra untagged line (for example * 3 EXISTS) in the stream the client parses; the LOGIN reflection is reachable before authentication.
3. drop CR and LF from the reason text at the shared emission point in ImapResponse (commandFailed, commandError, badResponse), matching the strip-on-emission handling already used for quota root names. Valid single-line reasons are unchanged.

Validation: added ErrorResponseLineInjectionTest which sends DELETE with a literal mailbox name carrying CRLF. On the current tree the response splits and a forged "X" line appears; after the change the reason stays on the single tagged line. The full greenmail-core test suite passes.