### PR TITLE
respect quoted strings when splitting mime parameters

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -646,13 +646,18 @@ public class SimpleMessageAttributes
         Set<String> params = null;
 
         public Header(String line) {
-            String[] strs = line.split(";");
-            if (0 != strs.length) {
-                value = strs[0];
+            List<String> strs = splitParameters(line);
+            if (!strs.isEmpty()) {
+                value = strs.get(0);
                 params = new HashSet<>();
-                for (int i = 1; i < strs.length; i++) {
-                    String p = strs[i].trim();
+                for (int i = 1; i < strs.size(); i++) {
+                    String p = strs.get(i).trim();
                     int e = p.indexOf('=');
+                    // A parameter without '=' (e.g. a stray token) is malformed; skip it
+                    // instead of indexing with -1, which threw StringIndexOutOfBoundsException.
+                    if (e < 0) {
+                        continue;
+                    }
                     String key = p.substring(0, e);
                     String val = p.substring(e + 1)
                         // Workaround for continuation bug?
@@ -662,6 +667,35 @@ public class SimpleMessageAttributes
                     params.add(p);
                 }
             }
+        }
+
+        /**
+         * Splits a Content-Type/Content-Disposition line on the ';' parameter
+         * separator, ignoring separators inside a quoted-string. A quoted value
+         * such as filename="Invoice; final.pdf" is legal (RFC 2045/2183) and must
+         * stay a single parameter rather than being cut at the embedded ';'.
+         */
+        private static List<String> splitParameters(String line) {
+            List<String> segments = new ArrayList<>();
+            StringBuilder current = new StringBuilder();
+            boolean inQuotes = false;
+            for (int i = 0; i < line.length(); i++) {
+                char c = line.charAt(i);
+                if (inQuotes && c == '\\' && i + 1 < line.length()) {
+                    // Keep an escaped character verbatim so \" does not end the quote.
+                    current.append(c).append(line.charAt(++i));
+                } else if (c == '"') {
+                    inQuotes = !inQuotes;
+                    current.append(c);
+                } else if (c == ';' && !inQuotes) {
+                    segments.add(current.toString());
+                    current.setLength(0);
+                } else {
+                    current.append(c);
+                }
+            }
+            segments.add(current.toString());
+            return segments;
         }
 
         public Set<String> getParams() {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureParameterSemicolonTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/BodyStructureParameterSemicolonTest.java
@@ -1,0 +1,47 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BodyStructureParameterSemicolonTest {
+
+    private String bodyStructure(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date()).getBodyStructure(true);
+    }
+
+    @Test
+    public void semicolonInsideQuotedFilenameKeepsSingleParameter() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain\r\n"
+            + "Content-Disposition: attachment; filename=\"Invoice; final.pdf\"\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"filename\" \"Invoice; final.pdf\"");
+    }
+
+    @Test
+    public void semicolonInsideQuotedContentTypeParameterKeepsSingleParameter() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain; name=\"a;b\"\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"name\" \"a;b\"");
+    }
+
+    @Test
+    public void parameterWithoutValueIsIgnored() throws Exception {
+        String bs = bodyStructure("From: a@b.com\r\n"
+            + "Content-Type: text/plain; charset=us-ascii; broken\r\n"
+            + "\r\nbody\r\n");
+        assertThat(bs).contains("\"charset\" \"us-ascii\"");
+    }
+}


### PR DESCRIPTION
1. SimpleMessageAttributes.Header splits the Content-Type and Content-Disposition parameter list with line.split(";"), which also cuts inside a quoted-string.
2. A legal quoted value that contains a semicolon, such as Content-Disposition: attachment; filename="Invoice; final.pdf", is broken apart; the fragment after the embedded ";" has no "=", so substring(0, indexOf("=")) indexes with -1 and throws StringIndexOutOfBoundsException. This parsing runs when a message is stored and for FETCH BODYSTRUCTURE, so a sender-supplied message crashes those paths; when a mis-split fragment does contain "=", the parameter list is silently corrupted instead.
3. Split the line while ignoring separators inside a quoted-string, and skip a parameter that has no "=" rather than indexing past the start.