### PR TITLE
Feature request: Add an option to discard attachment content after MIME validation #1020

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -879,6 +879,18 @@ tmp
                             </div>
                         </td>
                     </tr>
+                    <tr>
+                        <td class="text-nowrap">-Dgreenmail.attachments.discard</td>
+                        <td>
+                            <p>Configures whether attachments are discarded after basic MIME validation.</p>
+                            <p>
+                                Useful for performance tests where storing large attachments could exhaust memory.
+                            </p>
+                            <div class="bs-example">
+                                Example: <code>-Dgreenmail.attachments.discard=true</code>
+                            </div>
+                        </td>
+                    </tr>
                 </table>
                 </div>
 

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/ConfiguredGreenMail.java
@@ -28,6 +28,7 @@ public abstract class ConfiguredGreenMail implements GreenMailOperations {
             }
             getUserManager().setAuthRequired(!config.isAuthenticationDisabled());
             getUserManager().setSieveIgnoreDetail(config.isSieveIgnoreDetailEnabled());
+            getUserManager().setDiscardAttachments(config.isDiscardAttachmentsEnabled());
             if(config.hasPreloadDir()) {
                 try {
                     loadEmails(Paths.get(config.getPreloadDir()));

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/GreenMailConfiguration.java
@@ -11,6 +11,7 @@ public class GreenMailConfiguration {
     private final List<UserBean> usersToCreate = new ArrayList<>();
     private boolean disableAuthenticationCheck = false;
     private boolean sieveIgnoreDetail = false;
+    private boolean discardAttachments = false;
     private String preloadDir;
 
 
@@ -117,5 +118,28 @@ public class GreenMailConfiguration {
      */
     public boolean hasPreloadDir() {
         return null != preloadDir;
+    }
+
+    /**
+     * Disables storing of email attachments.
+     * <p>
+     * Useful for performance tests where large attachments would otherwise exhaust memory.
+     * GreenMail still accepts the email and validates addresses but discards any MIME parts
+     * identified as attachments before storing the message.
+     *
+     * @return Modified configuration.
+     */
+    public GreenMailConfiguration withDiscardAttachments() {
+        discardAttachments = true;
+        return this;
+    }
+
+    /**
+     * @return true if attachment discarding is enabled.
+     *
+     * @see GreenMailConfiguration#withDiscardAttachments()
+     */
+    public boolean isDiscardAttachmentsEnabled() {
+        return discardAttachments;
     }
 }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
@@ -44,6 +44,12 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
 
     public static final String GREENMAIL_SIEVE_IGNORE_DETAIL = "greenmail.sieve.ignore.detail";
     public static final String GREENMAIL_PRELOAD_DIR = "greenmail.preload.dir";
+    /**
+     * Discard attachments on delivery instead of storing them.
+     *
+     * @see GreenMailConfiguration#withDiscardAttachments()
+     */
+    public static final String GREENMAIL_DISCARD_ATTACHMENTS = "greenmail.discard.attachments";
 
     /**
      * Configures how user login should be extracted from user of pattern local-part:password@domain .
@@ -88,6 +94,11 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
         String preloadDir = properties.getProperty(GREENMAIL_PRELOAD_DIR);
         if (null != preloadDir) {
             configuration.withPreloadDir(preloadDir);
+        }
+
+        String discardAttachments = properties.getProperty(GREENMAIL_DISCARD_ATTACHMENTS, "false");
+        if (Boolean.TRUE.toString().equalsIgnoreCase(discardAttachments)) {
+            configuration.withDiscardAttachments();
         }
 
         return configuration;

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilder.java
@@ -49,7 +49,7 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
      *
      * @see GreenMailConfiguration#withDiscardAttachments()
      */
-    public static final String GREENMAIL_DISCARD_ATTACHMENTS = "greenmail.discard.attachments";
+    public static final String GREENMAIL_ATTACHMENTS_DISCARD = "greenmail.attachments.discard";
 
     /**
      * Configures how user login should be extracted from user of pattern local-part:password@domain .
@@ -96,7 +96,7 @@ public class PropertiesBasedGreenMailConfigurationBuilder {
             configuration.withPreloadDir(preloadDir);
         }
 
-        String discardAttachments = properties.getProperty(GREENMAIL_DISCARD_ATTACHMENTS, "false");
+        String discardAttachments = properties.getProperty(GREENMAIL_ATTACHMENTS_DISCARD, "false");
         if (Boolean.TRUE.toString().equalsIgnoreCase(discardAttachments)) {
             configuration.withDiscardAttachments();
         }

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/user/UserManager.java
@@ -9,10 +9,15 @@ package com.icegreen.greenmail.user;
 import com.icegreen.greenmail.imap.ImapHostManager;
 import com.icegreen.greenmail.mail.MailAddress;
 import com.icegreen.greenmail.mail.MovingMessage;
+import jakarta.mail.BodyPart;
 import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
@@ -31,6 +36,7 @@ public class UserManager {
     private final ImapHostManager imapHostManager;
     private boolean authRequired = true;
     private boolean sieveIgnoreDetailEnabled = false;
+    private boolean discardAttachmentsEnabled = false;
 
     private MessageDeliveryHandler messageDeliveryHandler = (msg, mailAddress) -> {
         String email;
@@ -147,6 +153,10 @@ public class UserManager {
         sieveIgnoreDetailEnabled = sieveIgnoreDetail;
     }
 
+    public void setDiscardAttachments(boolean discardAttachments) {
+        discardAttachmentsEnabled = discardAttachments;
+    }
+
     public ImapHostManager getImapHostManager() {
         return imapHostManager;
     }
@@ -181,7 +191,35 @@ public class UserManager {
     }
 
     public void deliver(MovingMessage msg, MailAddress mailAddress) throws MessagingException, UserException {
+        if (discardAttachmentsEnabled) {
+            stripAttachments(msg.getMessage());
+        }
         messageDeliveryHandler.handle(msg, mailAddress).deliver(msg);
+    }
+
+    private static void stripAttachments(MimeMessage message) throws MessagingException {
+        try {
+            Object content = message.getContent();
+            if (content instanceof Multipart) {
+                stripAttachmentParts((Multipart) content);
+                message.setContent((Multipart) content);
+                message.saveChanges();
+            }
+        } catch (IOException e) {
+            throw new MessagingException("Failed to strip attachments from message", e);
+        }
+    }
+
+    private static void stripAttachmentParts(Multipart multipart) throws MessagingException, IOException {
+        for (int i = multipart.getCount() - 1; i >= 0; i--) {
+            BodyPart part = multipart.getBodyPart(i);
+            String disposition = part.getDisposition();
+            if (Part.ATTACHMENT.equalsIgnoreCase(disposition) || part.getFileName() != null) {
+                multipart.removeBodyPart(i);
+            } else if (part.getContent() instanceof Multipart) {
+                stripAttachmentParts((Multipart) part.getContent());
+            }
+        }
     }
 
     /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/DiscardAttachmentsDefaultBehaviorTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/DiscardAttachmentsDefaultBehaviorTest.java
@@ -1,0 +1,59 @@
+package com.icegreen.greenmail;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that without the discard-attachments option, attachments are stored normally.
+ * Kept in a separate class so it can manage its own GreenMail lifecycle without
+ * conflicting with port assignments from other test rules.
+ */
+public class DiscardAttachmentsDefaultBehaviorTest {
+
+    private static final String TO = "to@example.com";
+    private static final String FROM = "from@example.com";
+
+    @Test
+    public void withoutOptionAttachmentIsStored() throws MessagingException, IOException {
+        GreenMail plain = new GreenMail(ServerSetupTest.SMTP);
+        plain.start();
+        try {
+            Session session = plain.getSmtp().createSession();
+            MimeMessage message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(FROM));
+            message.setRecipient(Message.RecipientType.TO, new InternetAddress(TO));
+            message.setSubject("no-discard");
+
+            MimeBodyPart textPart = new MimeBodyPart();
+            textPart.setText("body");
+
+            MimeBodyPart att = new MimeBodyPart();
+            att.setContent("data", "application/octet-stream");
+            att.setDisposition(Part.ATTACHMENT);
+            att.setFileName("file.bin");
+
+            MimeMultipart mp = new MimeMultipart();
+            mp.addBodyPart(textPart);
+            mp.addBodyPart(att);
+            message.setContent(mp);
+
+            Transport.send(message);
+
+            MimeMessage stored = plain.getReceivedMessages()[0];
+            Multipart multipart = (Multipart) stored.getContent();
+            assertThat(multipart.getCount()).isEqualTo(2);
+        } finally {
+            plain.stop();
+        }
+    }
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/DiscardAttachmentsTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/DiscardAttachmentsTest.java
@@ -1,0 +1,126 @@
+package com.icegreen.greenmail;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the discard-attachments option strips attachment MIME parts
+ * before storing a message, while preserving text body parts.
+ */
+public class DiscardAttachmentsTest {
+
+    private static final String TO = "to@example.com";
+    private static final String FROM = "from@example.com";
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.SMTP_IMAP)
+            .withConfiguration(new GreenMailConfiguration().withDiscardAttachments());
+
+    @Test
+    public void attachmentIsDiscarded() throws MessagingException, IOException {
+        sendMessageWithAttachment("body text", "attachment.txt", "attachment content");
+
+        MimeMessage[] received = greenMail.getReceivedMessages();
+        assertThat(received).hasSize(1);
+
+        MimeMessage stored = received[0];
+        assertThat(stored.getContent()).isInstanceOf(Multipart.class);
+
+        Multipart multipart = (Multipart) stored.getContent();
+        // Only the text body part should remain; the attachment part must be gone
+        assertThat(multipart.getCount()).isEqualTo(1);
+        assertThat(multipart.getBodyPart(0).getContentType()).startsWith("text/plain");
+        assertThat(multipart.getBodyPart(0).getContent()).isEqualTo("body text");
+    }
+
+    @Test
+    public void bodyTextIsPreserved() throws MessagingException, IOException {
+        sendMessageWithAttachment("hello world", "report.pdf", "PDF bytes");
+
+        MimeMessage stored = greenMail.getReceivedMessages()[0];
+        Multipart multipart = (Multipart) stored.getContent();
+        assertThat(multipart.getBodyPart(0).getContent()).isEqualTo("hello world");
+    }
+
+    @Test
+    public void plainTextMessageWithoutAttachmentIsUnaffected() throws MessagingException, IOException {
+        GreenMailUtil.sendTextEmailTest(TO, FROM, "subject", "plain body");
+
+        MimeMessage[] received = greenMail.getReceivedMessages();
+        assertThat(received).hasSize(1);
+        // Plain text messages have no Multipart content; content must pass through unchanged
+        assertThat(received[0].getContent().toString().trim()).isEqualTo("plain body");
+    }
+
+    @Test
+    public void multipleAttachmentsAreAllDiscarded() throws MessagingException, IOException {
+        Session session = greenMail.getSmtp().createSession();
+        MimeMessage message = new MimeMessage(session);
+        message.setFrom(new InternetAddress(FROM));
+        message.setRecipient(Message.RecipientType.TO, new InternetAddress(TO));
+        message.setSubject("multi-attachment");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("body");
+
+        MimeBodyPart att1 = new MimeBodyPart();
+        att1.setContent("data1", "application/octet-stream");
+        att1.setDisposition(Part.ATTACHMENT);
+        att1.setFileName("file1.bin");
+
+        MimeBodyPart att2 = new MimeBodyPart();
+        att2.setContent("data2", "application/pdf");
+        att2.setDisposition(Part.ATTACHMENT);
+        att2.setFileName("file2.pdf");
+
+        MimeMultipart mp = new MimeMultipart();
+        mp.addBodyPart(textPart);
+        mp.addBodyPart(att1);
+        mp.addBodyPart(att2);
+        message.setContent(mp);
+
+        Transport.send(message);
+
+        MimeMessage stored = greenMail.getReceivedMessages()[0];
+        Multipart multipart = (Multipart) stored.getContent();
+        assertThat(multipart.getCount()).isEqualTo(1);
+        assertThat(multipart.getBodyPart(0).getContent()).isEqualTo("body");
+    }
+
+    private void sendMessageWithAttachment(String bodyText, String fileName, String fileContent)
+            throws MessagingException {
+        Session session = greenMail.getSmtp().createSession();
+        MimeMessage message = new MimeMessage(session);
+        message.setFrom(new InternetAddress(FROM));
+        message.setRecipient(Message.RecipientType.TO, new InternetAddress(TO));
+        message.setSubject("test with attachment");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText(bodyText);
+
+        MimeBodyPart attachmentPart = new MimeBodyPart();
+        attachmentPart.setContent(fileContent, "application/octet-stream");
+        attachmentPart.setDisposition(Part.ATTACHMENT);
+        attachmentPart.setFileName(fileName);
+
+        MimeMultipart mp = new MimeMultipart();
+        mp.addBodyPart(textPart);
+        mp.addBodyPart(attachmentPart);
+        message.setContent(mp);
+
+        Transport.send(message);
+    }
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
@@ -85,7 +85,7 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
 
     @Test
     public void testBuildWithDiscardAttachmentsEnabled() {
-        Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_DISCARD_ATTACHMENTS, "true");
+        Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_ATTACHMENTS_DISCARD, "true");
         GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
         assertThat(config.isDiscardAttachmentsEnabled()).isTrue();
     }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/configuration/PropertiesBasedGreenMailConfigurationBuilderTest.java
@@ -83,6 +83,19 @@ public class PropertiesBasedGreenMailConfigurationBuilderTest {
         assertThat(config.getPreloadDir()).isEqualTo(preloadDir);
     }
 
+    @Test
+    public void testBuildWithDiscardAttachmentsEnabled() {
+        Properties props = createPropertiesFor(PropertiesBasedGreenMailConfigurationBuilder.GREENMAIL_DISCARD_ATTACHMENTS, "true");
+        GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(props);
+        assertThat(config.isDiscardAttachmentsEnabled()).isTrue();
+    }
+
+    @Test
+    public void testBuildWithDiscardAttachmentsDisabledByDefault() {
+        GreenMailConfiguration config = new PropertiesBasedGreenMailConfigurationBuilder().build(new Properties());
+        assertThat(config.isDiscardAttachmentsEnabled()).isFalse();
+    }
+
     private Properties createPropertiesFor(String key, String value) {
         Properties props = new Properties();
         props.setProperty(key, value);

--- a/greenmail-standalone/src/main/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunner.java
+++ b/greenmail-standalone/src/main/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunner.java
@@ -103,6 +103,8 @@ public class GreenMailStandaloneRunner {
             {"Note: Only has effect if configured user is of type email (i.e. contains '@')"},
             {"-Dgreenmail.auth.disabled ", "Disables authentication check so that any password works."},
             {"Also automatically provisions previously non-existent users."},
+            {"-Dgreenmail.discard.attachments=true", "Discards attachments on delivery instead of storing them."},
+            {"Useful for performance tests where large attachments would exhaust memory."},
             {"-Dgreenmail.verbose ", "Enables verbose mode, including JavaMail debug output"},
             {"-Dgreenmail.startup.timeout=<TIMEOUT_IN_MILLISECONDS>",
                 "Overrides the default server startup timeout of 1000ms."},

--- a/greenmail-standalone/src/main/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunner.java
+++ b/greenmail-standalone/src/main/java/com/icegreen/greenmail/standalone/GreenMailStandaloneRunner.java
@@ -103,7 +103,7 @@ public class GreenMailStandaloneRunner {
             {"Note: Only has effect if configured user is of type email (i.e. contains '@')"},
             {"-Dgreenmail.auth.disabled ", "Disables authentication check so that any password works."},
             {"Also automatically provisions previously non-existent users."},
-            {"-Dgreenmail.discard.attachments=true", "Discards attachments on delivery instead of storing them."},
+            {"-Dgreenmail.attachments.discard=true", "Discards attachments on delivery instead of storing them."},
             {"Useful for performance tests where large attachments would exhaust memory."},
             {"-Dgreenmail.verbose ", "Enables verbose mode, including JavaMail debug output"},
             {"-Dgreenmail.startup.timeout=<TIMEOUT_IN_MILLISECONDS>",


### PR DESCRIPTION
Introduces a new configuration flag that strips attachment MIME parts from incoming messages before storing them. This prevents large binary payloads from accumulating in the in-memory store during load/performance tests, avoiding out-of-memory conditions.

How to use:
  Standalone: -Dgreenmail.discard.attachments=true
  API:        GreenMailConfiguration.aConfig().withDiscardAttachments()

Text body parts (text/plain, text/html) are always preserved. Addresses and headers are fully validated as usual.