### PR TITLE
fix npe on content-type without a subtype

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -410,7 +410,14 @@ public class SimpleMessageAttributes
     void decodeContentType(String rawLine) {
         int slash = rawLine.indexOf('/');
         if (slash == -1) {
-//            if (DEBUG) getLogger().debug("decoding ... no slash found");
+            // A Content-Type value without a '/' carries no subtype (an empty or
+            // otherwise malformed header, e.g. "Content-Type: nonsense"). Leaving
+            // primaryType/secondaryType null makes the multipart/message checks below
+            // and the BODYSTRUCTURE emission throw a NullPointerException while the
+            // message is being stored, so fall back to the same default media type
+            // used for a missing Content-Type header.
+            primaryType = "text";
+            secondaryType = "plain";
             return;
         } else {
             primaryType = rawLine.substring(0, slash).trim();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/ContentTypeWithoutSubtypeTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/ContentTypeWithoutSubtypeTest.java
@@ -1,0 +1,47 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContentTypeWithoutSubtypeTest {
+
+    private SimpleMessageAttributes attributes(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date());
+    }
+
+    @Test
+    public void contentTypeWithoutSlashDoesNotFailStoring() throws Exception {
+        // Content-Type header carries no subtype ("no '/'"). Parsing must not throw.
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: nonsense\r\n"
+            + "\r\nbody\r\n").getBodyStructure(true);
+        assertThat(bs).startsWith("(\"text\" \"plain\"");
+    }
+
+    @Test
+    public void emptyContentTypeDoesNotFailStoring() throws Exception {
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: \r\n"
+            + "\r\nbody\r\n").getBodyStructure(true);
+        assertThat(bs).startsWith("(\"text\" \"plain\"");
+    }
+
+    @Test
+    public void contentTypeWithoutSlashButWithParametersDoesNotFailStoring() throws Exception {
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: weird; charset=us-ascii\r\n"
+            + "\r\nbody\r\n").getBodyStructure(true);
+        assertThat(bs).startsWith("(\"text\" \"plain\"");
+    }
+}


### PR DESCRIPTION
Repro: store or append a message whose Content-Type header has no subtype, e.g. `Content-Type: nonsense`, an empty `Content-Type:`, or `Content-Type: weird; charset=us-ascii`.
Cause: `SimpleMessageAttributes.decodeContentType` only assigns `primaryType`/`secondaryType` when the value contains a `/`. Without one it returns early and leaves both null, so `parseMimePart` hits `primaryType.equalsIgnoreCase(MULTIPART)` and throws a NullPointerException. This runs from the `StoredMessage` constructor at store time (SMTP delivery, IMAP APPEND) and for FETCH ENVELOPE/BODYSTRUCTURE, so a sender-supplied message that jakarta.mail parses fine cannot be stored or fetched.
Fix: in `decodeContentType`, fall back to the default `text/plain` media type when the value has no `/`, matching what jakarta.mail reports for a missing Content-Type. The fields stay non-null and a valid BODYSTRUCTURE is emitted. Values that contain a `/` are untouched.

Added `ContentTypeWithoutSubtypeTest`, which fails with a NullPointerException before the change and passes after.