### PR TITLE
reject unknown quota roots in GETQUOTA

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaCommand.java
@@ -35,8 +35,10 @@ public class GetQuotaCommand extends AuthenticatedStateCommand {
 
         String quotaRoot = parser.astring(request);
         // NAME root (name usage limit)
+        // GETQUOTA resolves a single named quota root, so do not fall back to the
+        // default root: an unknown root must be rejected (RFC 2087 section 4.2).
         Quota[] quota = session.getHost().getStore().getQuota(
-            quotaRoot, session.getUser().getQualifiedMailboxName());
+            quotaRoot, session.getUser().getQualifiedMailboxName(), false);
         if(null==quota||quota.length==0) {
             response.commandFailed(this, "No such quota root: "+quotaRoot);
         } else {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaRootCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/GetQuotaRootCommand.java
@@ -32,9 +32,10 @@ public class GetQuotaRootCommand extends GetQuotaCommand {
 
         String root = parser.mailbox(request);
         getMailbox(root, session, true);
-        // QUOTAROOT mailbox
+        // QUOTAROOT lists every quota root that applies to the mailbox, including the
+        // user's default root (RFC 2087 section 4.3).
         Quota[] quota = session.getHost().getStore().getQuota(
-                root, session.getUser().getQualifiedMailboxName());
+                root, session.getUser().getQualifiedMailboxName(), true);
         StringBuilder buf = new StringBuilder("QUOTAROOT ");
         buf.append(quoteName(root));
         for (Quota q : quota) {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
@@ -191,7 +191,7 @@ public class InMemoryStore
     }
 
     @Override
-    public Quota[] getQuota(final String root, final String qualifiedRootPrefix) {
+    public Quota[] getQuota(final String root, final String qualifiedRootPrefix, final boolean includeDefaultRoot) {
         Set<String> rootPaths = new HashSet<>();
         if (!root.contains(ImapConstants.HIERARCHY_DELIMITER)) {
             rootPaths.add(qualifiedRootPrefix + root);
@@ -200,7 +200,9 @@ public class InMemoryStore
                 rootPaths.add(qualifiedRootPrefix + r);
             }
         }
-        rootPaths.add(qualifiedRootPrefix); // Add default root
+        if (includeDefaultRoot) {
+            rootPaths.add(qualifiedRootPrefix); // Add default root
+        }
 
         Set<Quota> collectedQuotas = new HashSet<>();
         for (String p : rootPaths) {

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/Store.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/Store.java
@@ -109,9 +109,13 @@ public interface Store {
      * @see org.eclipse.angus.mail.imap.IMAPStore#getQuota(String)
      * @param root the quota root
      * @param qualifiedRootPrefix the user specific prefix
+     * @param includeDefaultRoot whether the user's default (empty) quota root is added to the lookup.
+     *                           GETQUOTAROOT lists every root that applies to a mailbox, which includes
+     *                           the default root; GETQUOTA looks up a single named root and must not
+     *                           fall back to it (RFC 2087, sections 4.2 and 4.3).
      * @return the quotas, or an empty array.
      */
-    Quota[] getQuota(String root, String qualifiedRootPrefix);
+    Quota[] getQuota(String root, String qualifiedRootPrefix, boolean includeDefaultRoot);
 
     /**
      * Sets the quota.

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -536,6 +536,42 @@ public class ImapProtocolTest {
         }
     }
 
+    @Test
+    public void testGetQuotaDoesNotFallBackToDefaultRoot() throws MessagingException {
+        greenMail.setUser("foo3@localhost", "pwd");
+        store.connect("foo3@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_ONLY);
+
+            // Set a quota on the default (empty) root.
+            IMAPFolder.ProtocolCommand set = protocol -> protocol.command("SETQUOTA \"\" (STORAGE 111)", null);
+            Response[] setRet = (Response[]) folder.doCommand(set);
+            assertThat(((IMAPResponse) setRet[0]).isOK()).isTrue();
+
+            // GETQUOTA on an unknown root must be rejected, not answered with the default root's quota.
+            IMAPFolder.ProtocolCommand unknown = protocol -> protocol.command("GETQUOTA \"whatever\"", null);
+            Response[] unknownRet = (Response[]) folder.doCommand(unknown);
+            IMAPResponse unknownResponse = (IMAPResponse) unknownRet[0];
+            assertThat(unknownResponse.isNO()).isTrue();
+            assertThat(unknownResponse.toString()).contains("No such quota root: whatever");
+
+            // GETQUOTA on the default root itself still returns it.
+            IMAPFolder.ProtocolCommand defaultRoot = protocol -> protocol.command("GETQUOTA \"\"", null);
+            Response[] defaultRet = (Response[]) folder.doCommand(defaultRoot);
+            assertThat((IMAPResponse) defaultRet[0]).hasToString("* QUOTA \"\" (STORAGE 0 111)");
+            assertThat(((IMAPResponse) defaultRet[1]).isOK()).isTrue();
+
+            // GETQUOTAROOT still reports the default root as applying to the mailbox.
+            IMAPFolder.ProtocolCommand quotaRoot = protocol -> protocol.command("GETQUOTAROOT INBOX", null);
+            Response[] quotaRootRet = (Response[]) folder.doCommand(quotaRoot);
+            assertThat(((IMAPResponse) quotaRootRet[0]).toString()).contains("QUOTAROOT \"INBOX\" \"\"");
+            assertThat((IMAPResponse) quotaRootRet[1]).hasToString("* QUOTA \"\" (STORAGE 0 111)");
+        } finally {
+            store.close();
+        }
+    }
+
     private String msnListToUidString(Map<Integer, Long> uids, int... msnList) {
         StringBuilder buf = new StringBuilder();
         for (int msn : msnList) {


### PR DESCRIPTION
1. InMemoryStore.getQuota always adds the user's default (empty) quota root to the lookup, so once any default-root quota exists, GETQUOTA for any name resolves to it.
2. GETQUOTA then reports the default root's usage and limits for a root the client did not ask for, and the "No such quota root" rejection is never reached (RFC 2087 section 4.2). GETQUOTAROOT does want the default root, since it lists every root that applies to a mailbox (section 4.3).

Added an includeDefaultRoot flag to getQuota: GETQUOTA passes false and rejects an unknown root, GETQUOTAROOT passes true and keeps its behavior. Regression test in ImapProtocolTest. Fixes #1024.