### PR TITLE
fix FETCH npe on message/rfc822 part without inner date

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -278,7 +278,15 @@ public class SimpleMessageAttributes
     private String parseEnvelope() {
         List<String> response = new ArrayList<>();
         //1. Date ---------------
-        response.add(LB + Q + escapeHeader(sentDateEnvelopeString) + Q + SP);
+        // env-date is an nstring (RFC 3501), so emit NIL when absent. A part built with no
+        // received-date fallback and no Date header (an embedded message/rfc822 whose inner
+        // message omits Date) leaves sentDateEnvelopeString null; passing null to escapeHeader
+        // would throw and fail the whole FETCH ENVELOPE/BODYSTRUCTURE.
+        if (sentDateEnvelopeString != null) {
+            response.add(LB + Q + escapeHeader(sentDateEnvelopeString) + Q + SP);
+        } else {
+            response.add(LB + NIL + SP);
+        }
         //2. Subject ---------------
         if (subject != null && (!subject.isEmpty())) {
             response.add(Q + escapeHeader(subject) + Q + SP);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeMissingDateTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/EnvelopeMissingDateTest.java
@@ -1,0 +1,58 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnvelopeMissingDateTest {
+
+    private SimpleMessageAttributes attributes(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date());
+    }
+
+    @Test
+    public void rfc822PartWithoutInnerDateFetchesBodyStructure() throws Exception {
+        // The inner message has no Date header, so the embedded part carries no envelope date.
+        // BODYSTRUCTURE embeds that part's ENVELOPE and must not fail on the missing date.
+        String inner = "From: inner@x.com\r\nSubject: hi\r\n\r\nbody\r\n";
+        String bs = attributes("From: a@b.com\r\n"
+            + "Subject: fwd\r\n"
+            + "Content-Type: message/rfc822\r\n"
+            + "\r\n" + inner).getBodyStructure(false);
+        assertThat(bs).startsWith("(\"MESSAGE\" \"RFC822\"");
+    }
+
+    @Test
+    public void rfc822PartWithoutInnerDateEmitsNilEnvelopeDate() throws Exception {
+        String inner = "From: inner@x.com\r\nSubject: hi\r\n\r\nbody\r\n";
+        SimpleMessageAttributes attrs = attributes("From: a@b.com\r\n"
+            + "Subject: fwd\r\n"
+            + "Content-Type: message/rfc822\r\n"
+            + "\r\n" + inner);
+        // The embedded ENVELOPE begins with a NIL date instead of a quoted empty string.
+        assertThat(attrs.getBodyStructure(false)).contains("(NIL \"hi\"");
+    }
+
+    @Test
+    public void rfc822AttachmentInMultipartFetchesBodyStructure() throws Exception {
+        // Common case: a forwarded mail attached as message/rfc822 whose inner message has no Date.
+        String inner = "From: inner@x.com\r\nSubject: hi\r\n\r\nbody\r\n";
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: multipart/mixed; boundary=\"B\"\r\n"
+            + "\r\n"
+            + "--B\r\nContent-Type: text/plain\r\n\r\nsee attached\r\n"
+            + "--B\r\nContent-Type: message/rfc822\r\n\r\n" + inner
+            + "--B--\r\n").getBodyStructure(false);
+        assertThat(bs).contains("\"MESSAGE\" \"RFC822\"");
+    }
+}


### PR DESCRIPTION
1. parseEnvelope emits the ENVELOPE date field through escapeHeader without a null guard, while the sibling fields (subject, in-reply-to, message-id) fall back to NIL. env-date is an nstring in RFC 3501 and may legitimately be absent.
2. An embedded message/rfc822 part builds its inner attributes with a null received date, so when the inner message carries no Date header sentDateEnvelopeString stays null. A FETCH BODYSTRUCTURE embeds that inner ENVELOPE, escapeHeader(null) throws, and the command fails with "Can not parse body structure". A sender can reach this with a forwarded mail attached as message/rfc822, including when nested inside a multipart part.

Emit NIL for a null envelope date so it matches the other fields. Top-level messages are unaffected since their received-date fallback keeps the date non-null. Added a regression test covering the direct and multipart-nested cases.
