### PR TITLE
reject STORE, EXPUNGE and MOVE on read-only selected mailbox

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/ExpungeCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/ExpungeCommand.java
@@ -53,6 +53,7 @@ class ExpungeCommand extends SelectedStateCommand implements UidEnabledCommand {
 
         if (session.getSelected().isReadonly()) {
             response.commandFailed(this, "Mailbox selected read only.");
+            return;
         }
 
         MailFolder folder = session.getSelected();

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/MoveCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/MoveCommand.java
@@ -55,6 +55,10 @@ class MoveCommand extends SelectedStateCommand implements UidEnabledCommand {
         parser.endLine(request);
 
         ImapSessionFolder currentMailbox = session.getSelected();
+        if (currentMailbox.isReadonly()) {
+            response.commandFailed(this, "Mailbox selected read only.");
+            return;
+        }
         MailFolder toFolder;
         try {
             toFolder = getMailbox(mailboxName, session, true);

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/StoreCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/StoreCommand.java
@@ -49,6 +49,10 @@ class StoreCommand extends SelectedStateCommand implements UidEnabledCommand {
         storeParser.endLine(request);
 
         ImapSessionFolder mailbox = session.getSelected();
+        if (mailbox.isReadonly()) {
+            response.commandFailed(this, "Mailbox selected read only.");
+            return;
+        }
 //        IdRange[] uidSet;
 //        if (useUids) {
 //           uidSet = idSet;

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapServerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapServerTest.java
@@ -246,7 +246,7 @@ public class ImapServerTest {
 
             // Set some flags
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
-            folder.open(Folder.READ_ONLY);
+            folder.open(Folder.READ_WRITE);
             try {
                 Message[] msgs = folder.getMessages();
                 assertThat(null != msgs && msgs.length == 1).isTrue();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -572,6 +572,44 @@ public class ImapProtocolTest {
         }
     }
 
+    @Test
+    public void testReadOnlyMailboxRejectsMutations() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+
+            // Mark a message deleted while read-write, then close without expunging.
+            folder.open(Folder.READ_WRITE);
+            folder.setFlags(new Message[]{folder.getMessage(1)}, new Flags(Flags.Flag.DELETED), true);
+            folder.close(false);
+
+            // EXAMINE selects the mailbox read only.
+            folder.open(Folder.READ_ONLY);
+
+            Response[] storeRet = (Response[]) folder.doCommand(
+                protocol -> protocol.command("STORE 2 +FLAGS (\\Flagged)", null));
+            assertThat(storeRet[storeRet.length - 1].isNO()).isTrue();
+
+            Response[] moveRet = (Response[]) folder.doCommand(
+                protocol -> protocol.command("MOVE 3 INBOX", null));
+            assertThat(moveRet[moveRet.length - 1].isNO()).isTrue();
+
+            Response[] expungeRet = (Response[]) folder.doCommand(
+                protocol -> protocol.command("EXPUNGE", null));
+            assertThat(expungeRet[expungeRet.length - 1].isNO()).isTrue();
+
+            folder.close(false);
+
+            // Reopen read-write and confirm none of the rejected commands changed state.
+            folder.open(Folder.READ_WRITE);
+            assertThat(folder.getMessageCount()).isEqualTo(10);
+            assertThat(folder.getMessage(2).isSet(Flags.Flag.FLAGGED)).isFalse();
+            folder.close(false);
+        } finally {
+            store.close();
+        }
+    }
+
     private String msnListToUidString(Map<Integer, Long> uids, int... msnList) {
         StringBuilder buf = new StringBuilder();
         for (int msn : msnList) {


### PR DESCRIPTION
Repro: `EXAMINE INBOX` selects the mailbox read only, then `STORE 1 +FLAGS (\Deleted)`, `EXPUNGE`, or `MOVE 1 Other` all still take effect.
Cause: `ExpungeCommand` checks `isReadonly()` and sends a tagged NO but is missing a `return`, so it falls through and expunges anyway; `StoreCommand` and `MoveCommand` have no read-only check, so STORE and MOVE mutate a mailbox that was selected with EXAMINE. RFC 3501 requires a read-only mailbox to reject these, and in the shared `#user` namespace this lets a session delete or reflag messages in a mailbox it opened read only.
Fix: add the missing `return` in EXPUNGE and the same `isReadonly()` guard to STORE and MOVE, kept at the command layer where CLOSE and EXPUNGE already perform the check. Adds a regression test; one existing flag test that opened the folder read only to set flags is corrected to read-write, which is the mode a client actually needs for STORE.