### PR TITLE
clear user keywords on STORE FLAGS replace

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/HierarchicalFolder.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/HierarchicalFolder.java
@@ -315,7 +315,10 @@ class HierarchicalFolder implements MailFolder, UIDFolder {
     public void replaceFlags(Flags flags, long uid, FolderListener silentListener, boolean addUid) throws FolderException {
         int msn = getMsn(uid);
         StoredMessage message = mailMessages.get(msn - 1);
-        message.setFlags(MessageFlags.ALL_FLAGS, false);
+        // Clear every currently set flag, not only the system flags in ALL_FLAGS, so the
+        // replace form of STORE also drops user keywords. getFlags() returns a copy, so
+        // clearing from it while mutating the message is safe.
+        message.setFlags(message.getFlags(), false);
         message.setFlags(flags, true);
 
         recordUserFlags(flags);

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -583,6 +583,36 @@ public class ImapProtocolTest {
     }
 
     @Test
+    public void testStoreReplaceFlagsClearsUserKeyword() throws MessagingException {
+        GreenMailUser user = greenMail.setUser("testStoreReplaceFlags@localhost", "pwd");
+        GreenMailUtil.sendTextEmail(user.getEmail(), user.getEmail(), "testStoreReplaceFlags", "content",
+            greenMail.getSmtp().getServerSetup());
+        store.connect("testStoreReplaceFlags@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_WRITE);
+
+            // Set a user keyword on the message
+            folder.setFlags(new int[]{1}, new Flags("MyKeyword"), true);
+            assertThat(folder.getMessage(1).getFlags().contains("MyKeyword")).isTrue();
+
+            // Replace form of STORE (no +/-): the resulting flag set must be exactly the argument
+            IMAPFolder.ProtocolCommand replace = protocol -> protocol.command("STORE 1 FLAGS (\\Seen)", null);
+            Response[] ret = (Response[]) folder.doCommand(replace);
+            assertThat(ret[ret.length - 1].isOK()).isTrue();
+
+            folder.close();
+            folder.open(Folder.READ_ONLY);
+
+            Flags flags = folder.getMessage(1).getFlags();
+            assertThat(flags.contains(Flags.Flag.SEEN)).isTrue();
+            assertThat(flags.contains("MyKeyword")).isFalse();
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
     public void testQuta() throws MessagingException {
         // JavaMail only uses GETQUOTAROOT, not GETQUOTA
         greenMail.setUser("foo2@localhost", "pwd");


### PR DESCRIPTION
HierarchicalFolder.replaceFlags clears the message flags with MessageFlags.ALL_FLAGS, which holds only the six system flags, before applying the new set, so the replace form of STORE (STORE n FLAGS (...), with no leading + or -) leaves any previously set user keyword in place instead of replacing the whole flag set. Now that custom keywords are supported the stale keyword is still reported by FETCH FLAGS and in the mailbox PERMANENTFLAGS even though the client asked to replace the flags. Clear the flags actually set on the message so replace drops user keywords too.