### PR TITLE
skip implicit \Seen on read-only mailbox in FETCH

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/FetchCommand.java
@@ -103,8 +103,11 @@ class FetchCommand extends SelectedStateCommand implements UidEnabledCommand {
         throws FolderException {
         // Check if this fetch will cause the "SEEN" flag to be set on this message
         // If so, update the flags, and ensure that a flags response is included in the response.
+        // A mailbox selected with EXAMINE is read only, so the implicit \Seen must not be
+        // set (RFC 3501 section 6.3.2); otherwise a non-peek BODY[] fetch mutates the shared
+        // message state the command was not permitted to change.
         boolean ensureFlagsResponse = false;
-        if (fetch.isSetSeen() && !message.isSet(Flags.Flag.SEEN)) {
+        if (fetch.isSetSeen() && !message.isSet(Flags.Flag.SEEN) && !folder.isReadonly()) {
             folder.setFlags(FLAGS_SEEN, true, message.getUid(), folder, useUids);
             message.setFlags(FLAGS_SEEN, true);
             ensureFlagsResponse = true;

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -96,7 +96,8 @@ public class ImapProtocolTest {
         store.connect("foo@localhost", "pwd");
         try {
             IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
-            folder.open(Folder.READ_ONLY);
+            // Read-write so the first non-peek BODY[HEADER] fetch sets \Seen and returns FLAGS.
+            folder.open(Folder.READ_WRITE);
 
             // Fetch without partial as reference
             Response[] ret = (Response[]) folder.doCommand(protocol -> protocol.command("UID FETCH 1 (BODY[HEADER])", null));
@@ -688,6 +689,32 @@ public class ImapProtocolTest {
             folder.open(Folder.READ_WRITE);
             assertThat(folder.getMessageCount()).isEqualTo(10);
             assertThat(folder.getMessage(2).isSet(Flags.Flag.FLAGGED)).isFalse();
+            folder.close(false);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void testReadOnlyFetchDoesNotSetSeen() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+
+            // EXAMINE selects the mailbox read only.
+            folder.open(Folder.READ_ONLY);
+
+            // A non-peek BODY[] fetch normally sets \Seen implicitly. On a read-only
+            // mailbox no permanent state may change, so the flag must stay unset.
+            Response[] fetchRet = (Response[]) folder.doCommand(
+                protocol -> protocol.command("FETCH 1 BODY[]", null));
+            assertThat(fetchRet[fetchRet.length - 1].isOK()).isTrue();
+
+            folder.close(false);
+
+            // Reopen read-write and confirm the fetch did not persist \Seen.
+            folder.open(Folder.READ_WRITE);
+            assertThat(folder.getMessage(1).isSet(Flags.Flag.SEEN)).isFalse();
             folder.close(false);
         } finally {
             store.close();


### PR DESCRIPTION
Repro: EXAMINE INBOX (read only), then FETCH 1 BODY[] for an unseen message.
Cause: outputMessage sets the implicit \Seen without checking isReadonly(), so a read-only fetch persists \Seen on the shared message; RFC 3501 6.3.2 forbids changing permanent state on a read-only mailbox.
Fix: only set \Seen when the mailbox is not read only, matching the isReadonly() guard STORE/EXPUNGE/MOVE/CLOSE already use.

Added a regression test that fetches BODY[] on a read-only INBOX and checks \Seen stays unset; an existing partial-fetch test that relied on the implicit \Seen now opens READ_WRITE.