### PR TITLE
fix FETCH BODYSTRUCTURE npe on multipart without parsable subparts

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -511,9 +511,16 @@ public class SimpleMessageAttributes
                 buf.append(parts[0].getBodyStructure(false)).append(SP);
                 buf.append(lineCount);
             } else if (primaryType.equalsIgnoreCase(MULTIPART)) {
-                for (MailMessageAttributes part : parts) {
-//                    setupLogger(parts[i]); // reset transient getLogger()
-                    buf.append(part.getBodyStructure(includeExtension));
+                // A sender can declare a multipart type whose body cannot be decomposed into
+                // parts (e.g. a multipart/* header with no boundary). parseMimePart swallows
+                // that failure and stores the message, but leaves parts null, so iterating it
+                // here would throw a NullPointerException and fail the whole FETCH BODYSTRUCTURE.
+                // Treat it like a multipart with no sub-parts, matching the count == 0 case.
+                if (parts != null) {
+                    for (MailMessageAttributes part : parts) {
+//                        setupLogger(parts[i]); // reset transient getLogger()
+                        buf.append(part.getBodyStructure(includeExtension));
+                    }
                 }
                 buf.append(SP + Q).append(escapeHeader(secondaryType)).append(Q);
             } else {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/MultipartWithoutBoundaryBodyStructureTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/MultipartWithoutBoundaryBodyStructureTest.java
@@ -1,0 +1,44 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class MultipartWithoutBoundaryBodyStructureTest {
+
+    private SimpleMessageAttributes attributes(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date());
+    }
+
+    @Test
+    public void multipartWithoutBoundaryFetchesBodyStructure() throws Exception {
+        // A sender declares multipart/* but the body can not be split into parts (no boundary).
+        // The message stores fine but leaves the parts array unset, so BODYSTRUCTURE must not
+        // dereference it and fail the whole FETCH.
+        SimpleMessageAttributes attrs = attributes("From: a@b.com\r\n"
+            + "Content-Type: multipart/mixed\r\n"
+            + "\r\nnot really multipart\r\n");
+        assertThatCode(() -> attrs.getBodyStructure(true)).doesNotThrowAnyException();
+        assertThat(attrs.getBodyStructure(true)).contains("\"mixed\"");
+    }
+
+    @Test
+    public void multipartAlternativeWithoutBoundaryFetchesBodyStructure() throws Exception {
+        SimpleMessageAttributes attrs = attributes("From: a@b.com\r\n"
+            + "Content-Type: multipart/alternative\r\n"
+            + "\r\nbody\r\n");
+        assertThatCode(() -> attrs.getBodyStructure(false)).doesNotThrowAnyException();
+        assertThat(attrs.getBodyStructure(false)).contains("\"alternative\"");
+    }
+}


### PR DESCRIPTION
1. a multipart/* message whose body cannot be decomposed into parts (for example a multipart/mixed header with no boundary) makes parseMimePart log the extraction failure and store the message with the parts array left null.
2. a later FETCH BODYSTRUCTURE takes the multipart branch of parseBodyStructure, iterates that null array, and throws, which surfaces as "Can not parse body structure" and fails the whole FETCH for the message range.

Guarded the multipart iteration against a null parts array so it emits the same result as an empty multipart (count == 0) instead of dereferencing null.

Confirmed with a store-then-fetch regression test that errors before the change and passes after; the rest of greenmail-core stays green.