### PR TITLE
validate literal octet count in consumeLiteralAsBytes

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
@@ -14,6 +14,7 @@ import org.eclipse.angus.mail.imap.protocol.BASE64MailboxDecoder;
 
 import jakarta.mail.Flags;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -35,6 +36,10 @@ public class CommandParser {
      * Carriage-Return '\r' character
      */
     static final char CHR_CR = '\r';
+    /**
+     * Chunk size used when reading a literal payload
+     */
+    private static final int LITERAL_CHUNK_SIZE = 8192;
 
     /**
      * Reads an argument of type "atom" from the request.
@@ -222,7 +227,12 @@ public class CommandParser {
             request.consume();
             next = request.nextChar();
         }
-        return Long.parseLong(atom.toString());
+        String digits = atom.toString();
+        try {
+            return Long.parseLong(digits);
+        } catch (NumberFormatException ex) {
+            throw new ProtocolException("Can not parse '" + digits + "' as number", ex);
+        }
     }
 
     /**
@@ -262,15 +272,60 @@ public class CommandParser {
         consumeChar(request, '}');
         consumeCRLF(request);
 
+        int size = literalOctetCount(digits.toString());
+
         if (synchronizedLiteral) {
             request.commandContinuationRequest();
         }
 
-        int size = Integer.parseInt(digits.toString());
-        byte[] buffer = new byte[size];
-        request.read(buffer);
+        return readLiteral(request, size);
+    }
 
-        return buffer;
+    /**
+     * Parses the octet count of a literal, which RFC 3501 defines as <code>number = 1*DIGIT</code>.
+     * A missing, signed, non numeric or out of range count is a syntax error, so it is reported
+     * as such instead of letting the conversion raise an unchecked exception that drops the
+     * connection before the command can be answered.
+     */
+    private int literalOctetCount(String digits) throws ProtocolException {
+        if (digits.isEmpty()) {
+            throw new ProtocolException("Invalid literal, octet count is missing");
+        }
+        for (int i = 0; i < digits.length(); i++) {
+            char chr = digits.charAt(i);
+            if (chr < '0' || chr > '9') {
+                throw new ProtocolException("Can not parse '" + digits + "' as literal octet count");
+            }
+        }
+        try {
+            return Integer.parseInt(digits);
+        } catch (NumberFormatException ex) {
+            throw new ProtocolException("Literal octet count '" + digits + "' is out of range", ex);
+        }
+    }
+
+    /**
+     * Reads the payload of a literal. Larger payloads are read in chunks so that the buffer
+     * grows with the octets that really arrive: the octet count is client supplied, and sizing
+     * a single buffer from it lets a client reserve arbitrary amounts of memory by announcing
+     * a literal it never sends.
+     */
+    private byte[] readLiteral(ImapRequestLineReader request, int size) throws ProtocolException {
+        if (size <= LITERAL_CHUNK_SIZE) {
+            byte[] buffer = new byte[size];
+            request.read(buffer);
+            return buffer;
+        }
+
+        ByteArrayOutputStream payload = new ByteArrayOutputStream(LITERAL_CHUNK_SIZE);
+        int remaining = size;
+        while (remaining > 0) {
+            byte[] chunk = new byte[Math.min(remaining, LITERAL_CHUNK_SIZE)];
+            request.read(chunk);
+            payload.write(chunk, 0, chunk.length);
+            remaining -= chunk.length;
+        }
+        return payload.toByteArray();
     }
 
     /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
@@ -40,4 +40,83 @@ public class CommandParserTest {
         ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
         return new CommandParser().consumeQuoted(new ImapRequestLineReader(in, null));
     }
+
+    @Test
+    public void consumeLiteralParsesRegularContent() throws ProtocolException {
+        assertThat(consumeLiteral("{5+}\r\nhello")).isEqualTo("hello");
+        assertThat(consumeLiteral("{0+}\r\n")).isEmpty();
+    }
+
+    @Test
+    public void consumeLiteralReadsPayloadLargerThanOneChunk() throws ProtocolException {
+        StringBuilder payload = new StringBuilder();
+        for (int i = 0; i < 20000; i++) {
+            payload.append((char) ('a' + i % 26));
+        }
+        assertThat(consumeLiteral("{" + payload.length() + "+}\r\n" + payload))
+            .isEqualTo(payload.toString());
+    }
+
+    @Test
+    public void consumeLiteralRejectsMissingOctetCount() {
+        assertThatThrownBy(() -> consumeLiteral("{+}\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void consumeLiteralRejectsNegativeOctetCount() {
+        assertThatThrownBy(() -> consumeLiteral("{-1+}\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void consumeLiteralRejectsNonNumericOctetCount() {
+        assertThatThrownBy(() -> consumeLiteral("{1a+}\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void consumeLiteralRejectsOutOfRangeOctetCount() {
+        assertThatThrownBy(() -> consumeLiteral("{9999999999+}\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    /**
+     * An announced octet count must not size a buffer on its own: the reader has to fail on the
+     * truncated payload rather than reserve the announced amount of memory up front.
+     */
+    @Test
+    public void consumeLiteralDoesNotReserveMemoryForAnAnnouncedPayload() {
+        long usedBefore = usedMemory();
+        assertThatThrownBy(() -> consumeLiteral("{1000000000+}\r\n"))
+            .isInstanceOf(ProtocolException.class);
+        assertThat(usedMemory() - usedBefore).isLessThan(100L * 1024 * 1024);
+    }
+
+    private static long usedMemory() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    @Test
+    public void consumeLongRejectsMissingNumber() {
+        assertThatThrownBy(() -> consumeLong(">\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void consumeLongRejectsOutOfRangeNumber() {
+        assertThatThrownBy(() -> consumeLong("99999999999999999999\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    private static String consumeLiteral(String line) throws ProtocolException {
+        ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
+        return new CommandParser().consumeLiteral(new ImapRequestLineReader(in, null));
+    }
+
+    private static long consumeLong(String line) throws ProtocolException {
+        ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
+        return new CommandParser().consumeLong(new ImapRequestLineReader(in, null));
+    }
 }


### PR DESCRIPTION
CommandParser.consumeLiteralAsBytes takes the octet count of an IMAP literal straight from the client and sizes a single buffer from it before any payload octet arrives, so the 22 byte pre-authentication line `a1 LOGIN {400000000}` leaves 365 MiB of server heap in use with nothing sent after it, and `{2147483647}` raises OutOfMemoryError. The count is also never checked against the RFC 3501 grammar `number = 1*DIGIT`, so `{-1}` throws NegativeArraySizeException while `{}` and `{9999999999}` throw NumberFormatException, and since CommandTemplate.process catches none of those the connection is dropped rather than the command failing with a tagged BAD. Validating the count and reading the payload in chunks that follow the octets actually received brings that same probe down to 1 MiB and makes the malformed forms answer BAD; consumeLong had the same unguarded conversion and now gets the treatment number() in this class already had. The new tests fail on master and pass with the change, and the full reactor build stays green.