### PR TITLE
resolve mailbox before INBOX guard in deleteMailbox

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHostManagerImpl.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHostManagerImpl.java
@@ -100,7 +100,7 @@ public class ImapHostManagerImpl
             // Delete mail boxes
             Collection<MailFolder> mailfolders = listMailboxes(user, "*");
             for(MailFolder mf : mailfolders) {
-                deleteMailbox(user, mf.getFullName());
+                deleteFolder(user, mf);
             }
 
             // Delete account mail box
@@ -161,11 +161,33 @@ public class ImapHostManagerImpl
     public void deleteMailbox(GreenMailUser user, String mailboxName)
         throws FolderException {
 
-        if (mailboxName.equalsIgnoreCase("inbox")) {
+        MailFolder toDelete = getFolder(user, mailboxName, true);
+
+        // Check the resolved folder, not the requested name: the store ignores empty
+        // path components, so eg "INBOX." and ".INBOX" address the very same folder.
+        if (isAccountInbox(toDelete)) {
             throw new FolderException("Can not delete INBOX mailbox for user " + user.getEmail());
         }
 
-        MailFolder toDelete = getFolder(user, mailboxName, true);
+        deleteFolder(user, toDelete);
+    }
+
+    /**
+     * Checks if the folder is an account inbox, ie <i>#mail.&lt;user&gt;.INBOX</i>.
+     *
+     * @param folder the folder.
+     * @return true, if the folder is an account inbox.
+     */
+    private static boolean isAccountInbox(MailFolder folder) {
+        StringTokenizer tokens = new StringTokenizer(folder.getFullName(), HIERARCHY_DELIMITER);
+        if (tokens.countTokens() != 3 || !USER_NAMESPACE.equals(tokens.nextToken())) {
+            return false;
+        }
+        tokens.nextToken(); // The user namespace
+        return INBOX_NAME.equals(tokens.nextToken());
+    }
+
+    private void deleteFolder(GreenMailUser user, MailFolder toDelete) throws FolderException {
         if (store.getChildren(toDelete).isEmpty()) {
             toDelete.deleteAllMessages();
             toDelete.signalDeletion();

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -1,5 +1,6 @@
 package com.icegreen.greenmail.imap.commands;
 
+import com.icegreen.greenmail.imap.ImapConstants;
 import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.store.FolderException;
 import com.icegreen.greenmail.user.GreenMailUser;
@@ -374,6 +375,35 @@ public class ImapProtocolTest {
             inbox.open(Folder.READ_ONLY);
             assertThat(inbox.exists()).isTrue();
 
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
+    public void testDeleteInboxByAliasedName() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_ONLY);
+
+            // Each of these resolves to the very same INBOX folder.
+            for (final String cmd : new String[]{
+                "DELETE \"INBOX.\"",
+                "DELETE \".INBOX\"",
+                "DELETE \"INBOX..\"",
+                "DELETE \"" + ImapConstants.USER_NAMESPACE + ImapConstants.HIERARCHY_DELIMITER
+                    + user.getQualifiedMailboxName() + ImapConstants.HIERARCHY_DELIMITER
+                    + ImapConstants.INBOX_NAME + "\""
+            }) {
+                Response[] ret = (Response[]) folder.doCommand(protocol -> protocol.command(cmd, null));
+                assertThat(ret[ret.length - 1].isNO()).as(cmd).isTrue();
+            }
+
+            final Folder inbox = store.getFolder("INBOX");
+            inbox.open(Folder.READ_ONLY);
+            assertThat(inbox.exists()).isTrue();
+            assertThat(inbox.getMessageCount()).isEqualTo(10);
         } finally {
             store.close();
         }


### PR DESCRIPTION
1. `deleteMailbox` compares the raw argument with `"inbox"`, but the store resolves a path with a `StringTokenizer` that drops empty components, so `DELETE "INBOX."`, `DELETE ".INBOX"`, `DELETE "INBOX.."` and the absolute `DELETE "#mail.<user>.INBOX"` all get past the guard onto the same folder.
2. The inbox is then emptied and unlinked, so `SELECT INBOX` reports no such folder and delivery to that account throws from then on, since `UserImpl.deliver` dereferences the now null inbox; the absolute form is not scoped to the session user, so it reaches another account's inbox too.
3. Moved the check behind `getFolder(...)` so it runs against the resolved folder and covers every spelling at once, and pulled the removal into a private `deleteFolder`, since `deletePrivateMailAccount` still has to drop the inbox when tearing an account down.

Added an `ImapProtocolTest` case over the four spellings; it fails on master and passes here, and the full reactor build stays green.