### PR TITLE
resolve new parent before detaching mailbox in renameMailbox

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/InMemoryStore.java
@@ -82,7 +82,7 @@ public class InMemoryStore
     }
 
     @Override
-    public void renameMailbox(MailFolder existingFolder, String newName) {
+    public void renameMailbox(MailFolder existingFolder, String newName) throws FolderException {
         HierarchicalFolder toRename = (HierarchicalFolder) existingFolder;
         HierarchicalFolder parent = toRename.getParent();
 
@@ -101,17 +101,41 @@ public class InMemoryStore
             // Simple rename
             toRename.setName(newFolderName);
         } else {
-            // Hierarchy change
+            // Hierarchy change. Resolve the target parent before detaching the mailbox,
+            // so a rename that can not be completed leaves the hierarchy untouched.
+            HierarchicalFolder newParent = resolveNewParent(toRename, newName);
             parent.removeChild(toRename);
-            HierarchicalFolder userFolder = getInboxOrUserRootFolder(toRename);
-            String[] path = newName.split('\\' + ImapConstants.HIERARCHY_DELIMITER);
-            HierarchicalFolder newParent = userFolder;
-            for (int i = 0; i < path.length - 1; i++) {
-                newParent = newParent.getChild(path[i]);
-            }
             toRename.moveToNewParent(newParent);
             toRename.setName(newFolderName);
         }
+    }
+
+    /**
+     * Looks up the parent a mailbox is moved to, without modifying the hierarchy.
+     *
+     * @param toRename the mailbox being renamed.
+     * @param newName  the new name, whose leading path components address the new parent.
+     * @return the new parent mailbox.
+     * @throws FolderException if the new parent does not exist or is the mailbox itself.
+     */
+    private HierarchicalFolder resolveNewParent(HierarchicalFolder toRename, String newName)
+        throws FolderException {
+        HierarchicalFolder newParent = getInboxOrUserRootFolder(toRename);
+        String[] path = newName.split('\\' + ImapConstants.HIERARCHY_DELIMITER);
+        for (int i = 0; i < path.length - 1; i++) {
+            newParent = newParent.getChild(path[i]);
+            if (null == newParent) {
+                throw new FolderException("Cannot rename mailbox " + toRename.getName() + " to " + newName
+                    + ", mailbox " + path[i] + " does not exist");
+            }
+        }
+        for (HierarchicalFolder ancestor = newParent; null != ancestor; ancestor = ancestor.getParent()) {
+            if (ancestor == toRename) {
+                throw new FolderException("Cannot rename mailbox " + toRename.getName() + " to " + newName
+                    + ", a mailbox can not become a child of itself");
+            }
+        }
+        return newParent;
     }
 
     private HierarchicalFolder getInboxOrUserRootFolder(HierarchicalFolder folder) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -405,6 +405,38 @@ public class ImapProtocolTest {
     }
 
     @Test
+    public void testRenameToUnusableParentKeepsMailbox() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_WRITE);
+
+            Response[] ret = (Response[]) folder.doCommand(protocol -> protocol.command("CREATE foo", null));
+            assertThat(ret[ret.length - 1].isOK()).isTrue();
+
+            ret = (Response[]) folder.doCommand(protocol -> protocol.command("COPY 1 foo", null));
+            assertThat(ret[ret.length - 1].isOK()).isTrue();
+
+            // The new parent does not exist, and a mailbox can not become a child of itself.
+            for (final String cmd : new String[]{"RENAME foo missing.bar", "RENAME foo foo.bar"}) {
+                Response[] renameRet = (Response[]) folder.doCommand(protocol -> protocol.command(cmd, null));
+                assertThat(renameRet[renameRet.length - 1].isNO()).isTrue();
+            }
+
+            folder.close(false);
+
+            // The rejected renames must not have dropped foo or the message it holds.
+            Folder foo = store.getFolder("foo");
+            assertThat(foo.exists()).isTrue();
+            foo.open(Folder.READ_ONLY);
+            assertThat(foo.getMessageCount()).isEqualTo(1);
+            foo.close(false);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
     public void testUidSearchTextWithCharset() throws MessagingException, IOException {
         greenMail.setUser("foo2@localhost", "pwd");
         store.connect("foo2@localhost", "pwd");


### PR DESCRIPTION
1. `InMemoryStore.renameMailbox` detaches the folder with `parent.removeChild` before it walks `newName` for the new parent, and that walk dereferences `getChild` without a null check.
2. `RENAME foo missing.bar` therefore loses `foo` and every message in it: the folder is unlinked, the source name no longer resolves, the target was never created, and `getAllMessages` drops those messages.
3. The NPE is not one of the exceptions `CommandTemplate.process` catches, so instead of a tagged NO it reaches `ImapHandler.run` and closes the connection.

`RENAME foo foo.bar` currently hits the same path, so resolving the parent up front also has to reject that case, otherwise the folder ends up as its own parent. Ordering now matches `deleteMailbox` in the same class, which validates before calling `removeChild`. Existing renames (top level, sibling under INBOX, move under an existing INBOX child) are unchanged, and `Store` already declares `renameMailbox` as throwing `FolderException`. Regression test added to `ImapProtocolTest`.
