### PR TITLE
Migrate and update Azul openjdk image to 21.0.12

### DIFF
--- a/greenmail-docker/standalone/Dockerfile
+++ b/greenmail-docker/standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:21.0.11-jre
+FROM azul-zulu:21.52-21.0.12-jre-headless-debian13
 
 LABEL org.opencontainers.image.url=https://github.com/greenmail-mail-test/greenmail/blob/master/greenmail-docker/standalone
 LABEL org.opencontainers.image.source=https://github.com/greenmail-mail-test/greenmail/blob/master/greenmail-docker/standalone/Dockerfile


### PR DESCRIPTION
- https://www.azul.com/blog/trusted-java-containers-azul-zulu-openjdk-joins-dockers-official-images/
- https://www.oracle.com/java/technologies/javase/21-0-12-relnotes.html