### PR TITLE
Delete nested mailboxes deepest-first when removing a user

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHostManagerImpl.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHostManagerImpl.java
@@ -97,21 +97,37 @@ public class ImapHostManagerImpl
     @Override
     public void deletePrivateMailAccount(GreenMailUser user) {
         try {
-            // Delete mail boxes
-            Collection<MailFolder> mailfolders = listMailboxes(user, "*");
-            for(MailFolder mf : mailfolders) {
+            // Delete deepest mailboxes first. deleteFolder only removes a folder when it has
+            // no children; a shallow-first walk leaves empty parents behind and then fails when
+            // removing the account root ("Cannot delete mailbox ... with children").
+            List<MailFolder> mailfolders = new ArrayList<>(listMailboxes(user, "*"));
+            mailfolders.sort(Comparator.comparingInt(ImapHostManagerImpl::mailboxDepth).reversed());
+            for (MailFolder mf : mailfolders) {
                 deleteFolder(user, mf);
             }
 
             // Delete account mail box
             MailFolder root = store.getMailbox(USER_NAMESPACE);
-            store.deleteMailbox(store.getMailbox(root,user.getQualifiedMailboxName()));
+            store.deleteMailbox(store.getMailbox(root, user.getQualifiedMailboxName()));
 
             // Delete Quota
             getStore().deleteQuota(user.getQualifiedMailboxName());
         } catch (FolderException e) {
             throw new IllegalStateException("Can not delete private mail account for " + user, e);
         }
+    }
+
+    /**
+     * Hierarchy depth of a mailbox full name ({@code #mail.user.INBOX} → 3).
+     */
+    private static int mailboxDepth(MailFolder folder) {
+        int depth = 0;
+        StringTokenizer tokens = new StringTokenizer(folder.getFullName(), HIERARCHY_DELIMITER);
+        while (tokens.hasMoreTokens()) {
+            tokens.nextToken();
+            depth++;
+        }
+        return depth;
     }
 
     /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/user/UserManagerTest.java
@@ -105,6 +105,31 @@ public class UserManagerTest {
     }
 
     @Test
+    public void testDeleteUserWithNestedMailboxes() throws Exception {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+
+        GreenMailUser user = userManager.createUser("foo@bar.com", "foo", "pwd");
+        imapHostManager.createMailbox(user, "parent");
+        imapHostManager.createMailbox(user, "parent.child");
+        imapHostManager.createMailbox(user, "parent.child.grandchild");
+        MailFolder leaf = imapHostManager.getFolder(user, "parent.child.grandchild");
+        ServerSetup ss = ServerSetupTest.IMAP;
+        MimeMessage m = GreenMailUtil.createTextEmail(
+            "there@localhost", "here@localhost", "sub", "msg", ss);
+        leaf.store(m);
+
+        userManager.deleteUser(user);
+
+        assertThat(userManager.listUser()).isEmpty();
+        assertThat(imapHostManager.getFolder(user, ImapConstants.INBOX_NAME)).isNull();
+        assertThat(imapHostManager.getFolder(user, "parent")).isNull();
+        assertThat(imapHostManager.getFolder(user, "parent.child")).isNull();
+        assertThat(imapHostManager.getFolder(user, "parent.child.grandchild")).isNull();
+        assertThat(imapHostManager.getAllMessages()).isEmpty();
+    }
+
+    @Test
     public void testNoAuthRequired() {
         ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
         UserManager userManager = new UserManager(imapHostManager);


### PR DESCRIPTION
## Summary

`UserManager.deleteUser` fails with `IllegalStateException` when the account still has a nested mailbox hierarchy (for example `parent.child.grandchild`).

`deleteFolder` only removes a mailbox when it has no children. Walking `listMailboxes(user, "*")` in arbitrary order can process a parent before its children, leave emptied parents in the tree, and then fail when deleting the account root with `Cannot delete mailbox ... with children`.

Sort mailboxes by hierarchy depth (deepest first) before calling `deleteFolder`.

Fixes #973

## Test plan

- [x] `./mvnw -pl greenmail-core -Dtest=UserManagerTest test` — 11/11 GREEN (includes new `testDeleteUserWithNestedMailboxes`)
- [x] `./mvnw -pl greenmail-core -Dtest=UserManagerTest,ImapServerTest test` — 34/34 GREEN