### PR TITLE
Avoid NPE when forcing IMAP close without an active response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHandler.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/ImapHandler.java
@@ -37,7 +37,12 @@ public class ImapHandler extends AbstractSocketProtocolHandler implements ImapCo
     }
 
     public void forceConnectionClose(final String message) {
-        response.byeResponse(message);
+        // response is null before run() starts and after close() clears handler state.
+        // deleteUser can still notify selected folders on a closed session (GH-902).
+        final ImapResponse currentResponse = response;
+        if (currentResponse != null) {
+            currentResponse.byeResponse(message);
+        }
         close();
     }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapHandlerTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/ImapHandlerTest.java
@@ -1,0 +1,34 @@
+package com.icegreen.greenmail.imap;
+
+import com.icegreen.greenmail.store.InMemoryStore;
+import com.icegreen.greenmail.user.UserManager;
+import org.junit.Test;
+
+import java.net.Socket;
+
+/**
+ * Regression for GH-902: deleteUser can notify IMAP sessions after the handler
+ * already cleared its response during close.
+ */
+public class ImapHandlerTest {
+
+    @Test
+    public void forceConnectionCloseWhenResponseNullDoesNotThrow() {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        ImapHandler handler = new ImapHandler(userManager, imapHostManager, new Socket());
+
+        // response is still null before run() starts (or after close() cleared it)
+        handler.forceConnectionClose("Mailbox INBOX has been deleted");
+    }
+
+    @Test
+    public void forceConnectionCloseAfterCloseDoesNotThrow() {
+        ImapHostManager imapHostManager = new ImapHostManagerImpl(new InMemoryStore());
+        UserManager userManager = new UserManager(imapHostManager);
+        ImapHandler handler = new ImapHandler(userManager, imapHostManager, new Socket());
+
+        handler.close();
+        handler.forceConnectionClose("Mailbox INBOX has been deleted");
+    }
+}


### PR DESCRIPTION
## Summary
`ImapHandler.forceConnectionClose` always called `response.byeResponse(...)`. When `deleteUser` notifies selected IMAP folders after the handler already cleared `response` in `close()`, that path threw NPE (`this.response` is null) as reported in #902.

Skip the BYE write when there is no active response and still close the connection.

## Test plan
- [x] RED: `ImapHandlerTest` fails with the reported NPE before the fix
- [x] GREEN: `./mvnw -pl greenmail-core -Dtest=ImapHandlerTest,UserManagerTest,ImapServerTest test` (36 tests)

Fixes #902