### PR TITLE
byte-stuff bare-lf dot lines in POP3 RETR response

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/RetrCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/pop3/commands/RetrCommand.java
@@ -42,9 +42,12 @@ public class RetrCommand
             }
 
             StoredMessage msg = msgList.get(0);
+            // RFC 1939 §3: every line of the message that begins with the termination
+            // octet must be byte-stuffed with an extra '.'. Anchoring only on CRLF misses
+            // lines that a stored message ends with a bare LF or CR, so stuff a leading
+            // '.' after any line boundary (and at the start of the message).
             String email = GreenMailUtil.getWholeMessage(msg.getMimeMessage())
-                // Byte-stuffing
-                .replaceAll("\r\n\\.","\r\n..");
+                .replaceAll("(^|\r\n|\r|\n)\\.", "$1..");
             conn.println("+OK");
             conn.println(email);
             conn.println(".");

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/pop3/POP3CommandTest.java
@@ -2,6 +2,8 @@ package com.icegreen.greenmail.pop3;
 
 import com.icegreen.greenmail.junit.GreenMailRule;
 import com.icegreen.greenmail.pop3.commands.AuthCommand;
+import com.icegreen.greenmail.store.MailFolder;
+import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.user.UserException;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -172,6 +174,37 @@ public class POP3CommandTest {
             printStream.print("PASS pwd" + CRLF);
             assertThat(reader.readLine()).startsWith("+OK");
             printStream.print("TOP 1 99" + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null && !".".equals(line)) {
+                lines.add(line);
+            }
+            assertThat(line).isEqualTo(".");
+            assertThat(lines).contains("..", "..dot", "last");
+        });
+    }
+
+    @Test
+    public void retrByteStuffsLinesEndingWithBareLf() throws Exception {
+        String to = "test@localhost";
+        GreenMailUser user = greenMail.setUser(to, "pwd");
+        // A stored message can carry bare LF line endings (SMTP DATA and IMAP APPEND
+        // write the body octets verbatim). RetrCommand only stuffed a leading "." that
+        // was preceded by CRLF, so a "." line ended with a bare LF reached the client
+        // unstuffed and terminated the multi-line RETR response at "first".
+        MailFolder inbox = greenMail.getManagers().getImapHostManager().getFolder(user, "INBOX");
+        inbox.store(GreenMailUtil.newMimeMessage(
+            "Subject: s\r\nFrom: from@localhost\r\n\r\nfirst\n.\n.dot\nlast\n"));
+
+        withConnection((printStream, reader) -> {
+            assertThat(reader.readLine()).startsWith("+OK POP3 GreenMail Server v");
+            printStream.print("USER " + to + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+            printStream.print("PASS pwd" + CRLF);
+            assertThat(reader.readLine()).startsWith("+OK");
+            printStream.print("RETR 1" + CRLF);
             assertThat(reader.readLine()).startsWith("+OK");
 
             List<String> lines = new ArrayList<>();


### PR DESCRIPTION
Repro: deliver a message whose body ends a "." line with a bare LF, then RETR it over POP3 (SMTP DATA and IMAP APPEND store the body octets verbatim); a client that treats LF as a line boundary reads the lone "." as the multi-line terminator, truncating the response and parsing the rest of the body as server responses.
Cause: RetrCommand only stuffed a leading "." preceded by CRLF, so a "." line ended with a bare LF or CR reached the client unstuffed, though RFC 1939 section 3 wants any line beginning with the termination octet stuffed (TopCommand already does).
Fix: stuff a leading "." after any line boundary; output for CRLF content is unchanged, and the added POP3CommandTest stores a bare-LF "." body and checks the RETR response is not truncated.
