### PR TITLE
fix array index in SaslXoauth2Message.parse on separator-less input

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslXoauth2Message.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/SaslXoauth2Message.java
@@ -70,7 +70,13 @@ public class SaslXoauth2Message {
                 throw new IllegalArgumentException("CR and LF are not allowed");
             }
             String[] parts = message.split("\\u0001");
-            if (parts.length > 2 || !parts[0].startsWith("user=") || !parts[1].startsWith("auth=Bearer ")) {
+            // A valid message splits into exactly the "user=" and "auth=Bearer " parts (the
+            // trailing ^A^A are dropped as empty). The length is validated before parts[1] is
+            // read: a message with fewer parts (e.g. "user=x" with no ^A separator) otherwise
+            // reached parts[1] and threw ArrayIndexOutOfBoundsException, which is not the
+            // IllegalArgumentException this method documents and which callers catch, so it
+            // escaped and tore down the connection instead of failing the auth attempt.
+            if (parts.length != 2 || !parts[0].startsWith("user=") || !parts[1].startsWith("auth=Bearer ")) {
                 throw new IllegalArgumentException("Invalid authentication string format");
             }
 

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslXoauth2MessageTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/util/SaslXoauth2MessageTest.java
@@ -26,6 +26,15 @@ public class SaslXoauth2MessageTest {
     }
 
     @Test
+    public void testParseRejectsMessageWithoutSeparator() {
+        // "user=x" with no ^A separator splits into a single part. Before validating the part
+        // count, parts[1] was read and threw ArrayIndexOutOfBoundsException, which is not the
+        // documented IllegalArgumentException and escaped the callers' catch blocks.
+        String encoded = Base64.getEncoder().encodeToString("user=x".getBytes());
+        assertThrows(IllegalArgumentException.class, () -> SaslXoauth2Message.parseBase64Encoded(encoded));
+    }
+
+    @Test
     public void testParseRejectsCrlfInUsername() {
         String ctrlA = String.valueOf((char) 1);
         String crlf = "" + (char) 13 + (char) 10;


### PR DESCRIPTION
1. SaslXoauth2Message.parse only rejects too many ^A-separated parts (parts.length > 2) and then reads parts[1] without checking that a second part is present.
2. A decoded XOAUTH2 initial-response that starts with "user=" but carries no ^A separator (for example "user=x") splits into a single element, so parts[1] throws ArrayIndexOutOfBoundsException instead of the IllegalArgumentException this method documents.
3. The POP3 AUTH XOAUTH2 handler wraps the call in catch(IllegalArgumentException) to answer -ERR, so the unchecked exception escapes and drops the pre-authentication connection rather than failing the auth attempt. The base64 initial-response comes from an unauthenticated client.

Changed the guard to require exactly two parts before indexing parts[1], which also matches the exact part-count check the sibling SaslMessage.parse already performs.

Validation:
- Added a SaslXoauth2MessageTest case for a separator-less message; it errors with ArrayIndexOutOfBoundsException before the change and passes after.
- The greenmail-core test suite stays green.