### PR TITLE
reject malformed SEARCH criteria with BAD instead of closing connection

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchCommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/SearchCommandParser.java
@@ -84,7 +84,7 @@ class SearchCommandParser extends CommandParser {
                     // Resolve group to single term
                     handleGroup(stack);
                 } else {
-                    throw new IllegalStateException("Unsupported atom special char <" + next + ">");
+                    throw new ProtocolException("Unsupported or misplaced character <" + next + "> in search criteria");
                 }
             } else {
                 String token = atomOnly(request);
@@ -133,14 +133,27 @@ class SearchCommandParser extends CommandParser {
         return handleOperators(stack);
     }
 
-    private void handleGroup(Deque<Object> stack) {
+    private void handleGroup(Deque<Object> stack) throws ProtocolException {
         Deque<Object> groupItems = new LinkedList<>();
         Object item;
-        while ((item = stack.pop()) != SearchOperator.GROUP) {
+        while (true) {
+            if (stack.isEmpty()) {
+                throw new ProtocolException("Unbalanced parenthesis in search criteria");
+            }
+            if ((item = stack.pop()) == SearchOperator.GROUP) {
+                break;
+            }
             groupItems.addLast(item);
         }
         final SearchTerm groupTerm = handleOperators(groupItems);
         stack.push(groupTerm);
+    }
+
+    private static SearchTerm requireOperand(Deque<SearchTerm> params) throws ProtocolException {
+        if (params.isEmpty()) {
+            throw new ProtocolException("Missing operand in search criteria");
+        }
+        return params.pop();
     }
 
     private void handleSearchArg(ImapRequestLineReader request, SearchKey key, SearchTermBuilder searchTermBuilder, Charset charset) throws ProtocolException {
@@ -158,7 +171,7 @@ class SearchCommandParser extends CommandParser {
         searchTermBuilder.addParameter(paramValue);
     }
 
-    private SearchTerm handleOperators(Deque<Object> stack) {
+    private SearchTerm handleOperators(Deque<Object> stack) throws ProtocolException {
         // Must be single term
         if (stack.size() == 1) {
             return (SearchTerm) stack.pop();
@@ -168,14 +181,14 @@ class SearchCommandParser extends CommandParser {
         while (!stack.isEmpty()) {
             final Object o = stack.pop();
             if (SearchOperator.OR == o) {
-                final SearchTerm term1 = params.pop();
-                final SearchTerm term2 = params.pop();
+                final SearchTerm term1 = requireOperand(params);
+                final SearchTerm term2 = requireOperand(params);
                 params.push(new OrTerm(term1, term2));
             } else if (SearchOperator.NOT == o) {
-                params.push(new NotTerm(params.pop()));
+                params.push(new NotTerm(requireOperand(params)));
             } else if (SearchOperator.AND == o) {
-                final SearchTerm term1 = params.pop();
-                final SearchTerm term2 = params.pop();
+                final SearchTerm term1 = requireOperand(params);
+                final SearchTerm term2 = requireOperand(params);
                 params.push(new AndTerm(term1, term2));
             } else if (SearchOperator.GROUP == o) {
                 // Size 0: Empty braces? Do nothing.
@@ -196,6 +209,8 @@ class SearchCommandParser extends CommandParser {
         if (params.size() > 1) {
             SearchTerm[] items = params.toArray(new SearchTerm[0]);
             return new AndTerm(items);
+        } else if (params.isEmpty()) {
+            throw new ProtocolException("Incomplete search criteria");
         } else {
             return params.pop();
         }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/ImapProtocolTest.java
@@ -222,6 +222,36 @@ public class ImapProtocolTest {
     }
 
     @Test
+    public void testMalformedSearchReturnsBadWithoutClosingConnection() throws MessagingException {
+        store.connect("foo@localhost", "pwd");
+        try {
+            IMAPFolder folder = (IMAPFolder) store.getFolder("INBOX");
+            folder.open(Folder.READ_ONLY);
+
+            for (final String cmd : new String[]{
+                "SEARCH *",
+                "SEARCH )",
+                "SEARCH (",
+                "SEARCH OR",
+                "SEARCH OR ANSWERED",
+                "SEARCH NOT"
+            }) {
+                Response[] ret = (Response[]) folder.doCommand(protocol -> protocol.command(cmd, null));
+                IMAPResponse last = (IMAPResponse) ret[ret.length - 1];
+                assertThat(last.isBAD()).as("expected BAD for '%s'", cmd).isTrue();
+
+                // The connection must still be usable after a rejected search.
+                Response[] ok = (Response[]) folder.doCommand(protocol -> protocol.command("SEARCH 1", null));
+                assertThat(((IMAPResponse) ok[0]).isBAD()).isFalse();
+                assertThat(((IMAPResponse) ok[0]).getRest()).isEqualTo("1");
+                assertThat(ok[ok.length - 1].isOK()).isTrue();
+            }
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test
     public void testUidSearchSequenceSet() throws MessagingException {
         store.connect("foo@localhost", "pwd");
         try {


### PR DESCRIPTION
1. SearchCommandParser.searchTerm resolves SEARCH criteria on an operator/term stack, and SearchCommand.doProcess wraps the parse in catch(UnsupportedCharsetException) and catch(IllegalArgumentException) to answer NO/BAD for bad input.
2. Two malformed forms slip past both catches and are never turned into a tagged response: a misplaced atom-special such as `SEARCH *` or `SEARCH {` throws IllegalStateException, and an operator or parenthesis with too few operands such as `SEARCH OR`, `SEARCH NOT` or `SEARCH )` pops an empty deque in handleOperators/handleGroup and throws NoSuchElementException. CommandTemplate.process only catches FolderException, AuthorizationException and ProtocolException, so either one reaches ImapHandler.run, is rethrown as IllegalStateException and the client connection is closed. SORT reuses the same parser and has the same exposure.
3. Made the parser honor its declared `throws ProtocolException` on malformed input: the misplaced-special branch throws ProtocolException, handleGroup reports an unbalanced parenthesis, and a small requireOperand helper plus an empty-result guard replace the unchecked pops in handleOperators. Malformed criteria now return a tagged BAD and the connection stays open; valid searches are unchanged.

Verified with a low-level regression test in ImapProtocolTest that sends `SEARCH *`, `SEARCH )`, `SEARCH (`, `SEARCH OR`, `SEARCH OR ANSWERED` and `SEARCH NOT`, asserts each returns BAD, and asserts a following `SEARCH 1` on the same connection still succeeds. It errors before the change and passes after. Full greenmail-core test suite is green.