### PR TITLE
reject malformed message set with BAD instead of closing connection

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/CommandParser.java
@@ -521,24 +521,33 @@ public class CommandParser {
         CharacterValidator validator = new MessageSetCharValidator();
         String nextWord = consumeWord(request, validator);
 
-        int commaPos = nextWord.indexOf(',');
-        if (commaPos == -1) {
-            return new IdRange[]{IdRange.parseRange(nextWord)};
-        }
+        // IdRange.parseRange raises an unchecked IllegalArgumentException for a malformed
+        // (e.g. "1:") or out of range (e.g. more digits than a long holds) message set.
+        // That is not caught by CommandTemplate.process, so it would drop the connection
+        // instead of failing the command; translate it into a ProtocolException so a
+        // tagged BAD is returned, as the sibling number/literal parsers already do.
+        try {
+            int commaPos = nextWord.indexOf(',');
+            if (commaPos == -1) {
+                return new IdRange[]{IdRange.parseRange(nextWord)};
+            }
 
-        List<IdRange> rangeList = new ArrayList<>();
-        int pos = 0;
-        while (commaPos != -1) {
-            String range = nextWord.substring(pos, commaPos);
-            IdRange set = IdRange.parseRange(range);
-            rangeList.add(set);
+            List<IdRange> rangeList = new ArrayList<>();
+            int pos = 0;
+            while (commaPos != -1) {
+                String range = nextWord.substring(pos, commaPos);
+                IdRange set = IdRange.parseRange(range);
+                rangeList.add(set);
 
-            pos = commaPos + 1;
-            commaPos = nextWord.indexOf(',', pos);
+                pos = commaPos + 1;
+                commaPos = nextWord.indexOf(',', pos);
+            }
+            String range = nextWord.substring(pos);
+            rangeList.add(IdRange.parseRange(range));
+            return rangeList.toArray(new IdRange[0]);
+        } catch (IllegalArgumentException ex) {
+            throw new ProtocolException("Invalid message set '" + nextWord + '\'', ex);
         }
-        String range = nextWord.substring(pos);
-        rangeList.add(IdRange.parseRange(range));
-        return rangeList.toArray(new IdRange[0]);
     }
 
     /**

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/CommandParserTest.java
@@ -110,6 +110,38 @@ public class CommandParserTest {
             .isInstanceOf(ProtocolException.class);
     }
 
+    @Test
+    public void parseIdRangeRejectsOutOfRangeNumber() {
+        assertThatThrownBy(() -> parseIdRange("99999999999999999999\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void parseIdRangeRejectsMalformedRange() {
+        assertThatThrownBy(() -> parseIdRange("1:\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void parseIdRangeRejectsEmptyRangeInList() {
+        assertThatThrownBy(() -> parseIdRange("1,,2\r\n"))
+            .isInstanceOf(ProtocolException.class);
+    }
+
+    @Test
+    public void parseIdRangeParsesRegularContent() throws ProtocolException {
+        IdRange[] ranges = parseIdRange("1,3:5\r\n");
+        assertThat(ranges).hasSize(2);
+        assertThat(ranges[0].getLowVal()).isEqualTo(1L);
+        assertThat(ranges[1].getLowVal()).isEqualTo(3L);
+        assertThat(ranges[1].getHighVal()).isEqualTo(5L);
+    }
+
+    private static IdRange[] parseIdRange(String line) throws ProtocolException {
+        ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
+        return new CommandParser().parseIdRange(new ImapRequestLineReader(in, null));
+    }
+
     private static String consumeLiteral(String line) throws ProtocolException {
         ByteArrayInputStream in = new ByteArrayInputStream(line.getBytes(StandardCharsets.ISO_8859_1));
         return new CommandParser().consumeLiteral(new ImapRequestLineReader(in, null));


### PR DESCRIPTION
1. CommandParser.parseIdRange hands each message-set token to IdRange.parseRange, which raises an unchecked IllegalArgumentException on a malformed range such as `1:` or `1,,2`, or on a count with more digits than a long holds such as `99999999999999999999`.
2. FETCH, COPY, MOVE, STORE and UID EXPUNGE all call parseIdRange first in doProcess, and IllegalArgumentException is not among the exceptions CommandTemplate.process catches (FolderException, AuthorizationException, ProtocolException), so it reaches ImapHandler.run, is rethrown as IllegalStateException and drops the connection instead of returning a tagged BAD.
3. Translated it to a ProtocolException inside parseIdRange, the shared parser for those commands, so a malformed set is reported the same way consumeLong and the literal octet count parser already report a bad number.

The SEARCH sequence-set path uses IdRange.parseRangeSequence directly and is already wrapped by SearchCommand's IllegalArgumentException catch, so it stays unchanged. Verified against CommandParserTest: a malformed or out-of-range set now yields a ProtocolException while valid sets like `1,3:5` parse as before.