### PR TITLE
use first content-disposition header when a message repeats it

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/store/SimpleMessageAttributes.java
@@ -770,9 +770,10 @@ public class SimpleMessageAttributes
             if (null == header || 0 == header.length) {
                 return null;
             }
-            if (header.length > 1) {
-                throw new IllegalArgumentException("Header creation assumes only one occurrence of header instead of " + header.length);
-            }
+            // A message may repeat a header such as Content-Disposition. RFC 5322 allows at
+            // most one, but a crafted message can carry several; use the first occurrence
+            // instead of throwing IllegalArgumentException, which escaped parseMimePart (it
+            // only catches MessagingException) and crashed message store and FETCH.
             return new Header(header[0]);
         }
     }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/store/MultipleContentDispositionBodyStructureTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/store/MultipleContentDispositionBodyStructureTest.java
@@ -1,0 +1,45 @@
+package com.icegreen.greenmail.store;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultipleContentDispositionBodyStructureTest {
+
+    private SimpleMessageAttributes attributes(String raw) throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage msg = new MimeMessage(session,
+            new ByteArrayInputStream(raw.getBytes(StandardCharsets.UTF_8)));
+        return new SimpleMessageAttributes(msg, new Date());
+    }
+
+    @Test
+    public void repeatedContentDispositionDoesNotFailStoring() throws Exception {
+        // Two Content-Disposition headers made Header.create throw IllegalArgumentException
+        // during construction, crashing message store and FETCH BODYSTRUCTURE.
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: text/plain\r\n"
+            + "Content-Disposition: attachment; filename=\"a.txt\"\r\n"
+            + "Content-Disposition: inline\r\n"
+            + "\r\nbody\r\n").getBodyStructure(true);
+        // First occurrence is used for the disposition extension field.
+        assertThat(bs).startsWith("(\"text\" \"plain\"");
+        assertThat(bs).contains("(\"attachment\" (\"filename\" \"a.txt\"))");
+    }
+
+    @Test
+    public void singleContentDispositionIsUnchanged() throws Exception {
+        String bs = attributes("From: a@b.com\r\n"
+            + "Content-Type: text/plain\r\n"
+            + "Content-Disposition: inline\r\n"
+            + "\r\nbody\r\n").getBodyStructure(true);
+        assertThat(bs).contains("\"inline\"");
+    }
+}


### PR DESCRIPTION
Header.create throws IllegalArgumentException when part.getHeader("Content-Disposition") returns more than one value, and parseMimePart only catches MessagingException, so a message carrying two Content-Disposition headers lets the exception escape the SimpleMessageAttributes constructor. That construction runs when a message is stored (SMTP delivery and IMAP APPEND) and again for FETCH BODYSTRUCTURE, so a crafted message crashes the parse instead of being handled: APPEND drops the connection because CommandTemplate.process does not catch it, delivery is aborted, and BODYSTRUCTURE over such a message fails. The fix uses the first occurrence rather than throwing, matching a field RFC 5322 permits at most once, and leaves single-header messages unchanged. Test added covering the repeated-header case and confirming the single-header output is untouched.