### PR TITLE
fail malformed SMTP and IMAP AUTH without closing the connection

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/AuthenticateCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/imap/commands/AuthenticateCommand.java
@@ -53,8 +53,18 @@ class AuthenticateCommand extends NonAuthenticatedStateCommand {
                 base64 = parser.astring(request);
             }
             parser.endLine(request);
-            // Create a new SASL message for XOAUTH2
-            SaslXoauth2Message xoauth2Message = SaslXoauth2Message.parseBase64Encoded(base64);
+            // Create a new SASL message for XOAUTH2. The decoder rejects malformed input
+            // (invalid base64, wrong part count, CR/LF in the decoded fields) with an
+            // IllegalArgumentException, so fail the attempt with a tagged NO instead of
+            // letting that escape and tear down the connection.
+            final SaslXoauth2Message xoauth2Message;
+            try {
+                xoauth2Message = SaslXoauth2Message.parseBase64Encoded(base64);
+            } catch (IllegalArgumentException ex) {
+                log.error("Expected base64 encoded XOAUTH2 message", ex);
+                response.commandFailed(this, "Invalid XOAUTH2 authentication string");
+                return;
+            }
             if (session.getUserManager().test(xoauth2Message.getUsername(), xoauth2Message.getAccessToken())) {
                 GreenMailUser user = session.getUserManager().getUser(xoauth2Message.getUsername());
                 session.setAuthenticated(user);

--- a/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/AuthCommand.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/smtp/commands/AuthCommand.java
@@ -90,7 +90,17 @@ public class AuthCommand extends SmtpCommand {
             initialResponse = commandParts[2];
         }
 
-        SaslMessage saslMessage = parseInitialResponse(initialResponse);
+        // decodeBase64 and SaslMessage.parse reject malformed input (invalid base64,
+        // wrong part count, CR/LF in the decoded fields) with an IllegalArgumentException.
+        // Fail the attempt with 535 instead of letting that escape and close the connection.
+        final SaslMessage saslMessage;
+        try {
+            saslMessage = parseInitialResponse(initialResponse);
+        } catch (IllegalArgumentException ex) {
+            log.error("Expected base64 encoded SASL PLAIN message", ex);
+            conn.send(AUTH_CREDENTIALS_INVALID);
+            return;
+        }
         AuthenticationState authenticationContext = new PlainAuthenticationState(saslMessage);
         state.getMessage().setAuthenticationState(authenticationContext);
 
@@ -113,15 +123,21 @@ public class AuthCommand extends SmtpCommand {
             String username = conn.readLine();
             conn.send(SMTP_SERVER_CONTINUATION + "UGFzc3dvcmQ6"); // "Password:"
             String pwd = conn.readLine();
-            String plainUsername = EncodingUtil.decodeBase64(username);
-            String plainPwd = EncodingUtil.decodeBase64(pwd);
-            AuthenticationState authenticationContext = new LoginAuthenticationState(plainUsername, plainPwd);
-            state.getMessage().setAuthenticationState(authenticationContext);
+            try {
+                String plainUsername = EncodingUtil.decodeBase64(username);
+                String plainPwd = EncodingUtil.decodeBase64(pwd);
+                AuthenticationState authenticationContext = new LoginAuthenticationState(plainUsername, plainPwd);
+                state.getMessage().setAuthenticationState(authenticationContext);
 
-            if (manager.getUserManager().test(plainUsername, plainPwd)) {
-                conn.setAuthenticated(true);
-                conn.send(AUTH_SUCCEDED);
-            } else {
+                if (manager.getUserManager().test(plainUsername, plainPwd)) {
+                    conn.setAuthenticated(true);
+                    conn.send(AUTH_SUCCEDED);
+                } else {
+                    conn.send(AUTH_CREDENTIALS_INVALID);
+                }
+            } catch (IllegalArgumentException ex) {
+                // Not valid base64: fail the attempt with 535 instead of closing the connection.
+                log.error("Expected base64 encoded user name and password for AUTH LOGIN", ex);
                 conn.send(AUTH_CREDENTIALS_INVALID);
             }
         }
@@ -132,15 +148,22 @@ public class AuthCommand extends SmtpCommand {
             conn.send(SMTP_SYNTAX_ERROR +
                 " : Unsupported auth mechanism with unexpected values. Line is: <" + Arrays.toString(commandParts) + ">");
         } else {
-            XOAuth2AuthenticationState authenticationContext = new XOAuth2AuthenticationState(
-                SaslXoauth2Message.parseBase64Encoded(commandParts[2]) );
-            state.getMessage().setAuthenticationState(authenticationContext);
+            try {
+                XOAuth2AuthenticationState authenticationContext = new XOAuth2AuthenticationState(
+                    SaslXoauth2Message.parseBase64Encoded(commandParts[2]) );
+                state.getMessage().setAuthenticationState(authenticationContext);
 
-            if (manager.getUserManager().test(authenticationContext.getUsername(),
-                authenticationContext.getAccessToken())) {
-                conn.setAuthenticated(true);
-                conn.send(AUTH_SUCCEDED);
-            } else {
+                if (manager.getUserManager().test(authenticationContext.getUsername(),
+                    authenticationContext.getAccessToken())) {
+                    conn.setAuthenticated(true);
+                    conn.send(AUTH_SUCCEDED);
+                } else {
+                    conn.send(AUTH_CREDENTIALS_INVALID);
+                }
+            } catch (IllegalArgumentException ex) {
+                // Not valid base64 or malformed XOAUTH2 message: fail the attempt with
+                // 535 instead of closing the connection.
+                log.error("Expected base64 encoded XOAUTH2 message", ex);
                 conn.send(AUTH_CREDENTIALS_INVALID);
             }
         }

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/AuthenticateCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/imap/commands/AuthenticateCommandTest.java
@@ -1,0 +1,63 @@
+package com.icegreen.greenmail.imap.commands;
+
+import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthenticateCommandTest {
+    private static final String CRLF = "\r\n";
+
+    @Rule
+    public final GreenMailRule greenMail = new GreenMailRule(ServerSetupTest.IMAP);
+
+    @Test
+    public void malformedXoauth2InitialResponseReturnsNoAndKeepsConnection() throws IOException {
+        greenMail.setUser("foo@localhost", "pwd");
+        String host = greenMail.getImap().getBindTo();
+        int port = greenMail.getImap().getPort();
+        try (Socket socket = new Socket(host, port);
+             PrintStream out = new PrintStream(socket.getOutputStream());
+             BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+            in.readLine(); // Greeting
+
+            // base64("user=x"): a decoded XOAUTH2 message without the ^A separator, so
+            // SaslXoauth2Message.parse rejects it. The server must answer with a tagged
+            // NO instead of closing the connection.
+            out.print("a1 AUTHENTICATE XOAUTH2 " + Base64.getEncoder().encodeToString(
+                "user=x".getBytes(StandardCharsets.UTF_8)) + CRLF);
+            List<String> authLines = readUntilTag(in, "a1");
+            assertThat(authLines).anyMatch(line ->
+                line.startsWith("a1 NO ") && line.contains("Invalid XOAUTH2 authentication string"));
+
+            // The connection must survive the failed attempt so the client can fall back to LOGIN.
+            out.print("a2 LOGIN foo@localhost pwd" + CRLF);
+            List<String> loginLines = readUntilTag(in, "a2");
+            assertThat(loginLines).anyMatch(line -> line.startsWith("a2 OK "));
+        }
+    }
+
+    private static List<String> readUntilTag(BufferedReader in, String tag) throws IOException {
+        List<String> lines = new ArrayList<>();
+        String line;
+        while ((line = in.readLine()) != null) {
+            lines.add(line);
+            if (line.startsWith(tag + " ")) {
+                break;
+            }
+        }
+        return lines;
+    }
+}

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/smtp/SMTPCommandTest.java
@@ -113,6 +113,46 @@ public class SMTPCommandTest {
     }
 
     @Test
+    public void authRejectsMalformedSaslResponseWithoutClosingConnection() throws IOException, MessagingException {
+        Session smtpSession = greenMail.getSmtp().createSession();
+        try (SMTPTransport smtpTransport = new SMTPTransport(smtpSession, smtpURL)) {
+            Socket smtpSocket = new Socket(hostAddress, port); // Closed by transport
+            smtpTransport.connect(smtpSocket);
+            assertThat(smtpTransport.isConnected()).isTrue();
+
+            // Undecodable base64: answer 535 and keep the connection open.
+            smtpTransport.issueCommand("AUTH PLAIN !!!not-base64!!!", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace(AuthCommand.AUTH_CREDENTIALS_INVALID);
+            smtpTransport.issueCommand("NOOP", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("250 Is that all?");
+
+            // A decoded PLAIN message carrying CR/LF is rejected by the SASL parser; same reply.
+            smtpTransport.issueCommand("AUTH PLAIN " + Base64.getEncoder().encodeToString(
+                "\u0000crlf\r\nuser\u0000pwd".getBytes(StandardCharsets.UTF_8)), -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace(AuthCommand.AUTH_CREDENTIALS_INVALID);
+            smtpTransport.issueCommand("NOOP", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("250 Is that all?");
+
+            // XOAUTH2 initial response without the required parts: same reply.
+            smtpTransport.issueCommand("AUTH XOAUTH2 " + Base64.getEncoder().encodeToString(
+                "user=x".getBytes(StandardCharsets.UTF_8)), -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace(AuthCommand.AUTH_CREDENTIALS_INVALID);
+            smtpTransport.issueCommand("NOOP", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("250 Is that all?");
+
+            // LOGIN exchange with an undecodable base64 user name/password: same reply.
+            smtpTransport.issueCommand("AUTH LOGIN", 334);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("334 VXNlcm5hbWU6" /* Username: */);
+            smtpTransport.issueCommand("!!!baduser!!!", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("334 UGFzc3dvcmQ6" /* Password: */);
+            smtpTransport.issueCommand("!!!badpass!!!", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace(AuthCommand.AUTH_CREDENTIALS_INVALID);
+            smtpTransport.issueCommand("NOOP", -1);
+            assertThat(smtpTransport.getLastServerResponse()).isEqualToNormalizingWhitespace("250 Is that all?");
+        }
+    }
+
+    @Test
     public void mailSenderAUTHSuffix() throws IOException, MessagingException {
         Session smtpSession = greenMail.getSmtp().createSession();
 


### PR DESCRIPTION
1. The shared SASL helpers (decodeBase64, SaslMessage.parse, SaslXoauth2Message.parse) reject malformed input with an unchecked IllegalArgumentException: invalid base64, a decoded message with the wrong part count, or CR/LF in a decoded field.
2. IMAP AUTHENTICATE XOAUTH2 and the SMTP AUTH PLAIN/LOGIN/XOAUTH2 handlers never catch it, so a bad initial response (or a LOGIN continuation line) closes the pre-authentication connection without a tagged NO or an SMTP reply. POP3 AUTH already fails the attempt with an error line, which leaves these handlers as the remaining sites.
3. Each handler now catches IllegalArgumentException and answers a tagged NO (IMAP) or 535 (SMTP), so the connection stays open and the client can retry or fall back to another mechanism.
4. Regression tests in SMTPCommandTest and AuthenticateCommandTest cover the SMTP PLAIN/LOGIN/XOAUTH2 paths and the IMAP XOAUTH2 path; all failed with the connection dropping before the fix.